### PR TITLE
Feat/df 270  limit forms

### DIFF
--- a/src/repositories/audit-record-repository.js
+++ b/src/repositories/audit-record-repository.js
@@ -4,14 +4,15 @@ import { AUDIT_RECORDS_COLLECTION_NAME, db } from '~/src/mongo.js'
 
 const logger = createLogger()
 
-const MAX_RECORDS = 1000
+const MAX_RECORDS = 100
 
 /**
  * Gets a filtered list of audit records
  * @param {Filter<WithId<AuditRecordInput>>} filter
+ * @param {number} skip
  * @returns {Promise<WithId<AuditRecordInput>[]>}
  */
-export async function getAuditRecords(filter) {
+export async function getAuditRecords(filter, skip) {
   logger.info('Reading audit records')
 
   const coll = /** @type {Collection<AuditRecordInput>} */ (
@@ -19,14 +20,18 @@ export async function getAuditRecords(filter) {
   )
 
   try {
-    const results = await coll.find(filter).limit(MAX_RECORDS).toArray()
+    const results = await coll
+      .find(filter)
+      .limit(MAX_RECORDS)
+      .skip(skip)
+      .toArray()
 
     logger.info('Read audit records')
 
     return results
-  } catch (e) {
-    logger.error(`Failed to read audit records - ${getErrorMessage(e)}`)
-    throw e
+  } catch (err) {
+    logger.error(`Failed to read audit records - ${getErrorMessage(err)}`)
+    throw err
   }
 }
 

--- a/src/repositories/audit-record-repository.js
+++ b/src/repositories/audit-record-repository.js
@@ -4,7 +4,7 @@ import { AUDIT_RECORDS_COLLECTION_NAME, db } from '~/src/mongo.js'
 
 const logger = createLogger()
 
-const MAX_RECORDS = 100
+const MAX_RECORDS = 1000
 
 /**
  * Gets a filtered list of audit records

--- a/src/repositories/audit-record-repository.test.js
+++ b/src/repositories/audit-record-repository.test.js
@@ -81,36 +81,49 @@ describe('audit-record-repository', () => {
   describe('getAuditRecords', () => {
     it('should get audit records', async () => {
       const toArrayStub = jest.fn().mockResolvedValueOnce([auditDocument])
-      const limitStub = jest.fn().mockReturnValue({
+      const skipStub = jest.fn().mockReturnValue({
         toArray: toArrayStub
+      })
+      const limitStub = jest.fn().mockReturnValue({
+        skip: skipStub
       })
       mockCollection.find.mockReturnValueOnce({
         limit: limitStub
       })
-      const auditRecords = await getAuditRecords({
-        entityId: STUB_AUDIT_RECORD_ID
-      })
+      const auditRecords = await getAuditRecords(
+        {
+          entityId: STUB_AUDIT_RECORD_ID
+        },
+        0
+      )
       const [filter] = mockCollection.find.mock.calls[0]
       expect(filter).toEqual({ entityId: STUB_AUDIT_RECORD_ID })
-      expect(limitStub).toHaveBeenCalledWith(1000)
+      expect(limitStub).toHaveBeenCalledWith(100)
       expect(auditRecords).toEqual([auditDocument])
+      expect(skipStub).toHaveBeenCalledWith(0)
     })
 
     it('should get audit records with skip count', async () => {
       const toArrayStub = jest.fn().mockResolvedValueOnce([auditDocument])
-      const limitStub = jest.fn().mockReturnValue({
+      const skipStub = jest.fn().mockReturnValue({
         toArray: toArrayStub
+      })
+      const limitStub = jest.fn().mockReturnValue({
+        skip: skipStub
       })
       mockCollection.find.mockReturnValueOnce({
         limit: limitStub
       })
-      const auditRecords = await getAuditRecords({
-        entityId: STUB_AUDIT_RECORD_ID
-      })
+      const auditRecords = await getAuditRecords(
+        {
+          entityId: STUB_AUDIT_RECORD_ID
+        },
+        20
+      )
       const [filter] = mockCollection.find.mock.calls[0]
       expect(filter).toEqual({ entityId: STUB_AUDIT_RECORD_ID })
-      expect(limitStub).toHaveBeenCalledWith(1000)
       expect(auditRecords).toEqual([auditDocument])
+      expect(skipStub).toHaveBeenCalledWith(20)
     })
 
     it('should handle get audit record failures', async () => {

--- a/src/repositories/audit-record-repository.test.js
+++ b/src/repositories/audit-record-repository.test.js
@@ -131,9 +131,12 @@ describe('audit-record-repository', () => {
         throw new Error('an error')
       })
       await expect(
-        getAuditRecords({
-          entityId: STUB_AUDIT_RECORD_ID
-        })
+        getAuditRecords(
+          {
+            entityId: STUB_AUDIT_RECORD_ID
+          },
+          0
+        )
       ).rejects.toThrow(new Error('an error'))
     })
   })

--- a/src/repositories/audit-record-repository.test.js
+++ b/src/repositories/audit-record-repository.test.js
@@ -92,7 +92,7 @@ describe('audit-record-repository', () => {
       })
       const [filter] = mockCollection.find.mock.calls[0]
       expect(filter).toEqual({ entityId: STUB_AUDIT_RECORD_ID })
-      expect(limitStub).toHaveBeenCalledWith(100)
+      expect(limitStub).toHaveBeenCalledWith(1000)
       expect(auditRecords).toEqual([auditDocument])
     })
 

--- a/src/repositories/audit-record-repository.test.js
+++ b/src/repositories/audit-record-repository.test.js
@@ -96,6 +96,23 @@ describe('audit-record-repository', () => {
       expect(auditRecords).toEqual([auditDocument])
     })
 
+    it('should get audit records with skip count', async () => {
+      const toArrayStub = jest.fn().mockResolvedValueOnce([auditDocument])
+      const limitStub = jest.fn().mockReturnValue({
+        toArray: toArrayStub
+      })
+      mockCollection.find.mockReturnValueOnce({
+        limit: limitStub
+      })
+      const auditRecords = await getAuditRecords({
+        entityId: STUB_AUDIT_RECORD_ID
+      })
+      const [filter] = mockCollection.find.mock.calls[0]
+      expect(filter).toEqual({ entityId: STUB_AUDIT_RECORD_ID })
+      expect(limitStub).toHaveBeenCalledWith(1000)
+      expect(auditRecords).toEqual([auditDocument])
+    })
+
     it('should handle get audit record failures', async () => {
       mockCollection.find.mockImplementation(() => {
         throw new Error('an error')

--- a/src/routes/form.js
+++ b/src/routes/form.js
@@ -9,20 +9,31 @@ import { readAuditEvents } from '~/src/service/events.js'
 export default {
   method: 'GET',
   path: '/audit/forms/{id}',
-  handler(request) {
-    const { params } = request
+  async handler(request) {
+    const { params, query } = request
     const { id } = params
-
-    return readAuditEvents({
-      category: AuditEventMessageCategory.FORM,
-      entityId: id
-    })
+    const { skip } = query
+    const skipCount = skip ?? 0
+    const auditRecords = await readAuditEvents(
+      {
+        category: AuditEventMessageCategory.FORM,
+        entityId: id
+      },
+      skipCount
+    )
+    return {
+      auditRecords,
+      skip: skipCount
+    }
   },
   options: {
     auth: false,
     validate: {
       params: Joi.object().keys({
         id: idSchema
+      }),
+      query: Joi.object().keys({
+        skip: Joi.number().optional()
       })
     }
   }

--- a/src/routes/form.js
+++ b/src/routes/form.js
@@ -13,17 +13,16 @@ export default {
     const { params, query } = request
     const { id } = params
     const { skip } = query
-    const skipCount = skip ?? 0
     const auditRecords = await readAuditEvents(
       {
         category: AuditEventMessageCategory.FORM,
         entityId: id
       },
-      skipCount
+      skip
     )
     return {
       auditRecords,
-      skip: skipCount
+      skip
     }
   },
   options: {
@@ -33,7 +32,7 @@ export default {
         id: idSchema
       }),
       query: Joi.object().keys({
-        skip: Joi.number().optional()
+        skip: Joi.number().default(0).optional()
       })
     }
   }

--- a/src/routes/form.js
+++ b/src/routes/form.js
@@ -1,4 +1,4 @@
-import { idSchema } from '@defra/forms-model'
+import { AuditEventMessageCategory, idSchema } from '@defra/forms-model'
 import Joi from 'joi'
 
 import { readAuditEvents } from '~/src/service/events.js'
@@ -14,6 +14,7 @@ export default {
     const { id } = params
 
     return readAuditEvents({
+      category: AuditEventMessageCategory.FORM,
       entityId: id
     })
   },

--- a/src/routes/form.test.js
+++ b/src/routes/form.test.js
@@ -28,6 +28,8 @@ describe('Forms audit route', () => {
   const formId = '688131eeff67f889d52c66cc'
 
   describe('Success responses', () => {
+    const formUpdateAuditRecord = buildFormUpdateAuditRecord()
+
     test('Testing GET /audit/forms/{id} route returns 200', async () => {
       const formUpdateAuditRecord = buildFormUpdateAuditRecord()
 
@@ -42,11 +44,42 @@ describe('Forms audit route', () => {
 
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
-      expect(response.result).toMatchObject([formUpdateAuditRecord])
-      expect(readAuditEvents).toHaveBeenCalledWith({
-        entityId: formId,
-        category: 'FORM'
+      expect(response.result).toMatchObject({
+        auditRecords: [formUpdateAuditRecord],
+        skip: 0
       })
+      expect(readAuditEvents).toHaveBeenCalledWith(
+        {
+          entityId: formId,
+          category: 'FORM'
+        },
+        0
+      )
+    })
+
+    test('Testing GET /audit/forms/{id} route returns 200 with skip parameter', async () => {
+      jest
+        .mocked(readAuditEvents)
+        .mockResolvedValueOnce([formUpdateAuditRecord])
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `/audit/forms/${formId}?skip=20`
+      })
+
+      expect(response.statusCode).toEqual(okStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+      expect(response.result).toMatchObject({
+        auditRecords: [formUpdateAuditRecord],
+        skip: 20
+      })
+      expect(readAuditEvents).toHaveBeenCalledWith(
+        {
+          entityId: formId,
+          category: 'FORM'
+        },
+        20
+      )
     })
 
     test('Testing GET /audit/forms/{id} route returns 500', async () => {

--- a/src/routes/form.test.js
+++ b/src/routes/form.test.js
@@ -43,6 +43,10 @@ describe('Forms audit route', () => {
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
       expect(response.result).toMatchObject([formUpdateAuditRecord])
+      expect(readAuditEvents).toHaveBeenCalledWith({
+        entityId: formId,
+        category: 'FORM'
+      })
     })
 
     test('Testing GET /audit/forms/{id} route returns 500', async () => {

--- a/src/service/events.js
+++ b/src/service/events.js
@@ -42,7 +42,7 @@ export function mapAuditEvent(message) {
 
 /**
  * Query audit records
- * @param {{ entityId: string }} filter
+ * @param {{ entityId: string; category?: AuditEventMessageCategory }} filter
  */
 export async function readAuditEvents(filter) {
   const results = await auditRecord.getAuditRecords(filter)
@@ -112,5 +112,5 @@ export async function createAuditEvents(messages) {
 
 /**
  * @import { Message } from '@aws-sdk/client-sqs'
- * @import { AuditRecordInput, AuditMessage } from '@defra/forms-model'
+ * @import { AuditRecordInput, AuditMessage, AuditEventMessageCategory } from '@defra/forms-model'
  */

--- a/src/service/events.js
+++ b/src/service/events.js
@@ -43,9 +43,10 @@ export function mapAuditEvent(message) {
 /**
  * Query audit records
  * @param {{ entityId: string; category?: AuditEventMessageCategory }} filter
+ * @param {number} skip
  */
-export async function readAuditEvents(filter) {
-  const results = await auditRecord.getAuditRecords(filter)
+export async function readAuditEvents(filter, skip) {
+  const results = await auditRecord.getAuditRecords(filter, skip)
 
   return results.map(mapAuditRecord)
 }

--- a/src/service/events.test.js
+++ b/src/service/events.test.js
@@ -187,7 +187,7 @@ describe('events', () => {
         .mocked(auditRecord.getAuditRecords)
         .mockResolvedValueOnce([auditDocument])
 
-      const auditRecords = await readAuditEvents({ entityId })
+      const auditRecords = await readAuditEvents({ entityId }, 0)
       expect(auditRecords).toEqual([expectedAuditRecord])
     })
   })


### PR DESCRIPTION
Sets the limit on the GET /audit/forms/:formid to 1,000 rather than 100 and fixes the api to only get forms.