### PR TITLE
fix/df-975: Collects metrics in batches

### DIFF
--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -499,16 +499,15 @@ export async function grabLock(session) {
 
 /**
  * Removes the metric control lock and updates the control record.
- * @param {boolean} success
- * @param {string} message
+ * @param {{ success: boolean, message: string, endDate: Date | undefined }} result
  * @param {ClientSession} session
  */
-export async function releaseLock(success, message, session) {
+export async function releaseLock({ success, message, endDate }, session) {
   const coll = getMetricCollection()
 
   const now = new Date()
 
-  const lastRunDate = success ? { lastSuccessfulRunDate: now } : {}
+  const lastRunDate = success ? { lastSuccessfulRunDate: endDate } : {}
 
   const updateObj = {
     $set: {
@@ -548,6 +547,13 @@ export async function clearMetricsData(session) {
       {
         type: { $ne: FORM_METRIC_CONTROL }
       },
+      { session }
+    )
+    await coll.updateOne(
+      {
+        type: FORM_METRIC_CONTROL
+      },
+      { $set: { lastSuccessfulRunDate: null } },
       { session }
     )
   } catch (err) {

--- a/src/repositories/metrics-repository.test.js
+++ b/src/repositories/metrics-repository.test.js
@@ -350,7 +350,10 @@ describe('metrics-repository', () => {
 
   describe('releaseLock', () => {
     it('should update control record to release lock with successful job', async () => {
-      await releaseLock(true, 'ok', mockSession)
+      await releaseLock(
+        { success: true, message: 'ok', endDate: new Date() },
+        mockSession
+      )
 
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
@@ -372,7 +375,10 @@ describe('metrics-repository', () => {
     })
 
     it('should update control record to release lock with failed job', async () => {
-      await releaseLock(false, 'some error text', mockSession)
+      await releaseLock(
+        { success: false, message: 'some error text', endDate: new Date() },
+        mockSession
+      )
 
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
@@ -397,9 +403,12 @@ describe('metrics-repository', () => {
         throw new Error('db error')
       })
 
-      await expect(() => releaseLock(true, 'ok', mockSession)).rejects.toThrow(
-        'db error'
-      )
+      await expect(() =>
+        releaseLock(
+          { success: true, message: 'ok', endDate: new Date() },
+          mockSession
+        )
+      ).rejects.toThrow('db error')
     })
   })
 

--- a/src/routes/report.js
+++ b/src/routes/report.js
@@ -2,6 +2,7 @@ import { Scopes } from '@defra/forms-model'
 import Joi from 'joi'
 
 import {
+  clearMetricsDatabase,
   generateReport,
   runMetricsCollectionJob
 } from '~/src/service/metrics.js'
@@ -44,9 +45,11 @@ export default [
   ({
     method: 'POST',
     path: '/report/regenerate',
-    handler(_request, h) {
+    async handler(_request, h) {
+      await clearMetricsDatabase()
+      // Fire-and-forget so UI doesn't timeout
       // eslint-disable-next-line no-void
-      void runMetricsCollectionJob(true)
+      void runMetricsCollectionJob()
       return h.response({ message: 'success' }).code(HTTP_OK)
     },
     options: {

--- a/src/service/metrics-helper.js
+++ b/src/service/metrics-helper.js
@@ -1,0 +1,91 @@
+import { FormMetricName, FormStatus } from '@defra/forms-model'
+import { format } from 'date-fns'
+
+export const CalculationTypes = {
+  Accumulation: 'Accumulation',
+  Snapshot: 'Snapshot',
+  Average: 'Average'
+}
+
+export const metricConfig =
+  /** { Record<FormMetricName, { calculationType: string }>} */ {
+    [FormMetricName.NewFormsCreated]: {
+      calculationType: CalculationTypes.Accumulation
+    },
+    [FormMetricName.FormsPublished]: {
+      calculationType: CalculationTypes.Accumulation
+    },
+    [FormMetricName.Submissions]: {
+      calculationType: CalculationTypes.Accumulation
+    },
+    [FormMetricName.FormsInDraft]: {
+      calculationType: CalculationTypes.Snapshot
+    },
+    [FormMetricName.TimeToPublish]: {
+      calculationType: CalculationTypes.Average
+    }
+  }
+
+/**
+ * @typedef {object} CollectionJobResult
+ * @property {boolean} success - true if job was successful
+ * @property {string} message - success message or error message
+ * @property { Date | undefined } endDate - end date
+ * @property {boolean} processMoreBatches - true if more batches need processing
+ */
+
+/**
+ * @param {Date} date
+ */
+export function formatDateOnly(date) {
+  return format(date, 'yyyy-MM-dd')
+}
+
+/**
+ * @param {string} inDateStr
+ * @param {Date} inTime
+ */
+export function setTimeOnDate(inDateStr, inTime) {
+  return new Date(`${inDateStr}T${format(inTime, 'HH:mm:ss')}.000Z`)
+}
+
+/**
+ * @param {Date} date
+ * @param {Date} startOfRange
+ * @param {Date} endOfRange
+ */
+export function dateFallsInsideTimeslot(date, startOfRange, endOfRange) {
+  return date >= startOfRange && date < endOfRange
+}
+
+/**
+ * @param {FormTimelineMetric} metric
+ */
+export function isDraftSubmission(metric) {
+  return (
+    metric.metricName === FormMetricName.Submissions.toString() &&
+    metric.formStatus === FormStatus.Draft
+  )
+}
+
+/**
+ * @param {FormTimelineMetric} metric
+ */
+export function isLiveSubmission(metric) {
+  return (
+    metric.metricName === FormMetricName.Submissions.toString() &&
+    metric.formStatus === FormStatus.Live
+  )
+}
+
+/**
+ * @param {FormTimelineMetric} metric
+ */
+export function getMetricCalcType(metric) {
+  const metricName = /** @type {FormMetricName} */ (metric.metricName)
+  return metricConfig[metricName].calculationType
+}
+
+/**
+ * @import { FormTimelineMetric } from '@defra/forms-model'
+ */

--- a/src/service/metrics-helper.test.js
+++ b/src/service/metrics-helper.test.js
@@ -1,0 +1,9 @@
+import { setTimeOnDate } from '~/src/service/metrics-helper.js'
+
+describe('setTimeOnDate', () => {
+  it('should set time on date', () => {
+    const testDateStr = '2026-02-05'
+    const expectedDate = new Date('2026-02-05T08:59:34.000Z')
+    expect(setTimeOnDate(testDateStr, expectedDate)).toEqual(expectedDate)
+  })
+})

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -662,8 +662,11 @@ export function applyExtraColumns(metrics) {
   const formRepublished = createFormMap(metrics.totals.republished)
 
   return metrics.overview.map((metric) => ({
+    featureMetrics: metric.featureMetrics,
     summaryMetrics: metric.summaryMetrics,
+    formId: metric.formId,
     formName: metric.summaryMetrics.name,
+    formStatus: metric.formStatus,
     submissionsCount:
       (metric.formStatus === FormStatus.Live
         ? submissionCountsLive.get(metric.formId)

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -7,6 +7,7 @@ import {
   add,
   differenceInDays,
   format,
+  min,
   startOfDay,
   sub,
   subDays,
@@ -45,6 +46,9 @@ import {
 const managerUrl = config.get('managerUrl')
 const submissionUrl = config.get('submissionUrl')
 
+const MAX_DAYS_PER_BATCH = 30
+const EARLIER_REPORT_DATE_AS_STRING = '2025-07-01'
+
 const CalculationTypes = {
   Accumulation: 'Accumulation',
   Snapshot: 'Snapshot',
@@ -71,6 +75,14 @@ const metricConfig =
   }
 
 /**
+ * @typedef {object} CollectionJobResult
+ * @property {boolean} success - true if job was successful
+ * @property {string} message - success message or error message
+ * @property { Date | undefined } endDate - end date
+ * @property {boolean} processMoreBatches - true if more batches need processing
+ */
+
+/**
  * @param {Date} date
  */
 export function formatDateOnly(date) {
@@ -78,15 +90,51 @@ export function formatDateOnly(date) {
 }
 
 /**
- * Collect metrics
- * @param {boolean} deleteDatabase
+ * @param {string} inDateStr
+ * @param {Date} inTime
  */
-export async function runMetricsCollectionJob(deleteDatabase = false) {
-  logger.info('[metrics] metrics job started')
-  const result = {
-    success: false,
-    message: ''
+export function setTimeOnDate(inDateStr, inTime) {
+  return new Date(`${inDateStr}T${format(inTime, 'HH:mm:ss')}.000Z`)
+}
+
+/**
+ * Delete all metrics records from teh database (apart from the control record)
+ */
+export async function clearMetricsDatabase() {
+  const session = client.startSession()
+  try {
+    await session.withTransaction(async () => {
+      await clearMetricsData(session)
+    })
+  } finally {
+    await session.endSession()
   }
+}
+
+/**
+ * Collect metrics (this may involve multiple batches being collected)
+ */
+export async function runMetricsCollectionJob() {
+  let continueProcessingBatches = true
+  do {
+    continueProcessingBatches = await runMetricsCollectionBatch()
+  } while (continueProcessingBatches)
+}
+
+/**
+ * Collect a batch of metrics
+ * @returns {Promise<boolean>} stopBatches
+ */
+export async function runMetricsCollectionBatch() {
+  logger.info('[metrics] metrics job started')
+
+  let result = /* @type {CollectionJobResult} */ {
+    success: false,
+    processMoreBatches: false,
+    message: '',
+    endDate: /** @type { Date | undefined } */ (undefined)
+  }
+
   const session = client.startSession()
   try {
     const jobStart = new Date()
@@ -96,46 +144,66 @@ export async function runMetricsCollectionJob(deleteDatabase = false) {
         '[metrics] metrics job aborting as another container already has a lock'
       )
       logger.info('[metrics] metrics job finished')
-      return
+      return true
     }
 
     await session.withTransaction(async () => {
-      if (deleteDatabase) {
-        await clearMetricsData(session)
-        lockResult.lastSuccessfulRun = null
-      }
-      await collectMetrics(jobStart, lockResult.lastSuccessfulRun, session)
-      result.success = true
-      result.message = 'Completed ok'
+      result = await collectMetrics(
+        jobStart,
+        lockResult.lastSuccessfulRun,
+        MAX_DAYS_PER_BATCH,
+        session
+      )
     })
   } catch (err) {
     const message = getErrorMessage(err)
     logger.error(err, `[metrics] metrics job failed - ${message}`)
     result.message = message
   } finally {
-    await releaseLock(result.success, result.message, session)
+    await releaseLock(result, session)
     await session.endSession()
   }
 
   logger.info('[metrics] metrics job finished')
+  return result.processMoreBatches
 }
 
 /**
  * Collect a full set of metrics - both overview and snapshot
  * @param {Date} jobStart
  * @param { Date | null } lastSuccessfulRunDate
+ * @param {number} daysPerBatch
  * @param {ClientSession} session
+ * @returns {Promise<CollectionJobResult>}
  */
-export async function collectMetrics(jobStart, lastSuccessfulRunDate, session) {
+export async function collectMetrics(
+  jobStart,
+  lastSuccessfulRunDate,
+  daysPerBatch,
+  session
+) {
+  // Make a call for each day since last job run
+  // (Normally only one day but also handles full historical data population on first run)
+  // For full historical catch-up, it runs in batches until we reach 'yesterday' inclusive)
+  const yesterday = sub(new Date(), { days: 1 })
+  let reportDate =
+    lastSuccessfulRunDate ??
+    setTimeOnDate(EARLIER_REPORT_DATE_AS_STRING, yesterday)
+  const maxDate = min([add(reportDate, { days: daysPerBatch }), yesterday])
+
+  if (formatDateOnly(reportDate) >= formatDateOnly(maxDate)) {
+    return {
+      success: false,
+      message: 'Skipped',
+      endDate: undefined,
+      processMoreBatches: false
+    }
+  }
+
   logger.info('[metrics] getting overview metrics')
   await collectManagerOverviewMetrics(jobStart, session)
 
-  // Make a call for each day since last job run
-  // (Normally only one day but also handles full historical data population on first run)
-  const yesterday = sub(jobStart, { days: 1 })
-  let reportDate = lastSuccessfulRunDate ?? sub(jobStart, { days: 480 })
-
-  while (formatDateOnly(reportDate) <= formatDateOnly(yesterday)) {
+  while (formatDateOnly(reportDate) <= formatDateOnly(maxDate)) {
     logger.info(
       `[metrics] getting timeline metrics for ${reportDate.toISOString()}`
     )
@@ -144,8 +212,14 @@ export async function collectMetrics(jobStart, lastSuccessfulRunDate, session) {
     reportDate = add(reportDate, { days: 1 })
   }
 
-  const totals = await recalcMetrics(yesterday, session)
-  await updateMetricTotals(yesterday, totals, session)
+  const totals = await recalcMetrics(maxDate, session)
+  await updateMetricTotals(maxDate, totals, session)
+  return {
+    success: true,
+    message: 'Completed ok',
+    processMoreBatches: formatDateOnly(reportDate) < formatDateOnly(yesterday),
+    endDate: maxDate
+  }
 }
 
 /**

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -83,7 +83,7 @@ export async function runMetricsCollectionJob() {
 
 /**
  * Collect a batch of metrics
- * @returns {Promise<boolean>} stopBatches
+ * @returns {Promise<boolean>} continueBatches
  */
 export async function runMetricsCollectionBatch() {
   logger.info('[metrics] metrics job started')
@@ -104,7 +104,7 @@ export async function runMetricsCollectionBatch() {
         '[metrics] metrics job aborting as another container already has a lock'
       )
       logger.info('[metrics] metrics job finished')
-      return true
+      return false
     }
 
     await session.withTransaction(async () => {

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -6,7 +6,6 @@ import {
 import {
   add,
   differenceInDays,
-  format,
   min,
   startOfDay,
   sub,
@@ -35,6 +34,15 @@ import {
   saveFormTimelineMetrics,
   updateMetricTotals
 } from '~/src/repositories/metrics-repository.js'
+import {
+  CalculationTypes,
+  dateFallsInsideTimeslot,
+  formatDateOnly,
+  getMetricCalcType,
+  isDraftSubmission,
+  isLiveSubmission,
+  setTimeOnDate
+} from '~/src/service/metrics-helper.js'
 
 /**
  * @typedef {object} FilterCriteria
@@ -47,55 +55,7 @@ const managerUrl = config.get('managerUrl')
 const submissionUrl = config.get('submissionUrl')
 
 const MAX_DAYS_PER_BATCH = 30
-const EARLIER_REPORT_DATE_AS_STRING = '2025-07-01'
-
-const CalculationTypes = {
-  Accumulation: 'Accumulation',
-  Snapshot: 'Snapshot',
-  Average: 'Average'
-}
-
-const metricConfig =
-  /** { Record<FormMetricName, { calculationType: string }>} */ {
-    [FormMetricName.NewFormsCreated]: {
-      calculationType: CalculationTypes.Accumulation
-    },
-    [FormMetricName.FormsPublished]: {
-      calculationType: CalculationTypes.Accumulation
-    },
-    [FormMetricName.Submissions]: {
-      calculationType: CalculationTypes.Accumulation
-    },
-    [FormMetricName.FormsInDraft]: {
-      calculationType: CalculationTypes.Snapshot
-    },
-    [FormMetricName.TimeToPublish]: {
-      calculationType: CalculationTypes.Average
-    }
-  }
-
-/**
- * @typedef {object} CollectionJobResult
- * @property {boolean} success - true if job was successful
- * @property {string} message - success message or error message
- * @property { Date | undefined } endDate - end date
- * @property {boolean} processMoreBatches - true if more batches need processing
- */
-
-/**
- * @param {Date} date
- */
-export function formatDateOnly(date) {
-  return format(date, 'yyyy-MM-dd')
-}
-
-/**
- * @param {string} inDateStr
- * @param {Date} inTime
- */
-export function setTimeOnDate(inDateStr, inTime) {
-  return new Date(`${inDateStr}T${format(inTime, 'HH:mm:ss')}.000Z`)
-}
+const EARLIEST_REPORT_DATE_AS_STRING = '2025-07-01'
 
 /**
  * Delete all metrics records from teh database (apart from the control record)
@@ -185,13 +145,19 @@ export async function collectMetrics(
   // Make a call for each day since last job run
   // (Normally only one day but also handles full historical data population on first run)
   // For full historical catch-up, it runs in batches until we reach 'yesterday' inclusive)
-  const yesterday = sub(new Date(), { days: 1 })
-  let reportDate =
+  const yesterday = sub(jobStart, { days: 1 })
+  // Reporting start date = last-successful-run + 1, or a fixed time in the past just before events were being stored
+  let reportDate = add(
     lastSuccessfulRunDate ??
-    setTimeOnDate(EARLIER_REPORT_DATE_AS_STRING, yesterday)
-  const maxDate = min([add(reportDate, { days: daysPerBatch }), yesterday])
+      setTimeOnDate(EARLIEST_REPORT_DATE_AS_STRING, yesterday),
+    { days: 1 }
+  )
+  const reportEndDate = min([
+    add(reportDate, { days: daysPerBatch }),
+    yesterday
+  ])
 
-  if (formatDateOnly(reportDate) >= formatDateOnly(maxDate)) {
+  if (formatDateOnly(reportDate) >= formatDateOnly(reportEndDate)) {
     return {
       success: false,
       message: 'Skipped',
@@ -203,7 +169,7 @@ export async function collectMetrics(
   logger.info('[metrics] getting overview metrics')
   await collectManagerOverviewMetrics(jobStart, session)
 
-  while (formatDateOnly(reportDate) <= formatDateOnly(maxDate)) {
+  while (formatDateOnly(reportDate) <= formatDateOnly(reportEndDate)) {
     logger.info(
       `[metrics] getting timeline metrics for ${reportDate.toISOString()}`
     )
@@ -212,13 +178,13 @@ export async function collectMetrics(
     reportDate = add(reportDate, { days: 1 })
   }
 
-  const totals = await recalcMetrics(maxDate, session)
-  await updateMetricTotals(maxDate, totals, session)
+  const totals = await recalcMetrics(reportEndDate, session)
+  await updateMetricTotals(reportEndDate, totals, session)
   return {
     success: true,
     message: 'Completed ok',
     processMoreBatches: formatDateOnly(reportDate) < formatDateOnly(yesterday),
-    endDate: maxDate
+    endDate: reportEndDate
   }
 }
 
@@ -457,43 +423,6 @@ export function updateMetricAverage(metric, period) {
   } else {
     period[metricName] = { avgTotal: metric.metricValue, avgCount: 1 }
   }
-}
-
-/**
- * @param {Date} date
- * @param {Date} startOfRange
- * @param {Date} endOfRange
- */
-function dateFallsInsideTimeslot(date, startOfRange, endOfRange) {
-  return date >= startOfRange && date < endOfRange
-}
-
-/**
- * @param {FormTimelineMetric} metric
- */
-function isDraftSubmission(metric) {
-  return (
-    metric.metricName === FormMetricName.Submissions.toString() &&
-    metric.formStatus === FormStatus.Draft
-  )
-}
-
-/**
- * @param {FormTimelineMetric} metric
- */
-function isLiveSubmission(metric) {
-  return (
-    metric.metricName === FormMetricName.Submissions.toString() &&
-    metric.formStatus === FormStatus.Live
-  )
-}
-
-/**
- * @param {FormTimelineMetric} metric
- */
-function getMetricCalcType(metric) {
-  const metricName = /** @type {FormMetricName} */ (metric.metricName)
-  return metricConfig[metricName].calculationType
 }
 
 /**
@@ -753,4 +682,5 @@ export function applyExtraColumns(metrics) {
 /**
  * @import { ClientSession, FindCursor, WithId } from 'mongodb'
  * @import { AuditRecordInput, FormOverviewMetric, FormTimelineMetric, FormTotalsMetric } from '@defra/forms-model'
+ * @import { CollectionJobResult } from '~/src/service/metrics-helper.js'
  */

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -662,12 +662,15 @@ describe('runMetricsCollectionJob', () => {
         overview: [
           {
             daysToPublish: 0,
+            formId: 'form-id-1',
             formName: 'Form 1',
+            formStatus: 'live',
             republished: 0,
             submissionsCount: 0,
             summaryMetrics: {
               name: 'Form 1'
-            }
+            },
+            featureMetrics: {}
           }
         ],
         totals: []
@@ -716,17 +719,23 @@ describe('runMetricsCollectionJob', () => {
       expect(res).toEqual([
         {
           daysToPublish: 15,
+          formId: 'form-id-1',
           formName: 'Form 1',
+          formStatus: 'live',
           republished: 2,
           submissionsCount: 5,
-          summaryMetrics: { name: 'Form 1' }
+          summaryMetrics: { name: 'Form 1' },
+          featureMetrics: undefined
         },
         {
           daysToPublish: undefined,
+          formId: 'form-id-2',
           formName: 'Form 2',
+          formStatus: 'draft',
           republished: undefined,
           submissionsCount: 9,
-          summaryMetrics: { name: 'Form 2' }
+          summaryMetrics: { name: 'Form 2' },
+          featureMetrics: undefined
         }
       ])
     })

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -22,13 +22,13 @@ import {
   applyExtraColumns,
   clearMetricsDatabase,
   collectManagerOverviewMetrics,
+  collectMetrics,
   collectTimelineMetrics,
   collectTimelineMetricsFromAudit,
   generateReport,
   recalcMetrics,
   runMetricsCollectionJob,
   setMetricTotal,
-  setTimeOnDate,
   updateMetricAverage,
   updateMetricTotal
 } from '~/src/service/metrics.js'
@@ -67,6 +67,50 @@ function createTimelineMetric(
     metricName,
     createdAt: new Date(dateStr),
     metricValue
+  }
+}
+
+const firstCreated = /** @type {AuditRecordInput[]} */ ([
+  {
+    type: 'FORM_CREATED',
+    entityId: 'form-id-1a',
+    createdAt: new Date('2026-03-30')
+  }
+])
+const mockAsyncIteratorFirstCreated = {
+  [Symbol.asyncIterator]: function* () {
+    for (const metric of firstCreated) {
+      yield metric
+    }
+  }
+}
+const draftCreatedFromLive = /** @type {AuditRecordInput[]} */ ([
+  {
+    type: 'FORM_CREATED',
+    entityId: 'form-id-1a',
+    createdAt: new Date('2026-03-30')
+  }
+])
+const mockAsyncIteratorDraftCreatedFromLive = {
+  [Symbol.asyncIterator]: function* () {
+    for (const metric of draftCreatedFromLive) {
+      yield metric
+    }
+  }
+}
+
+const firstPublished = /** @type {AuditRecordInput[]} */ ([
+  {
+    type: 'FORM_DRAFT_CREATED_FROM_LIVE',
+    entityId: 'form-id-1a',
+    createdAt: new Date('2026-04-08')
+  }
+])
+const mockAsyncIteratorFirstPublished = {
+  [Symbol.asyncIterator]: function* () {
+    for (const metric of firstPublished) {
+      yield metric
+    }
   }
 }
 
@@ -115,10 +159,11 @@ describe('runMetricsCollectionJob', () => {
   })
 
   it('should run job when able to lock', async () => {
+    const threeDaysAgo = startOfDay(sub(now, { days: 3 }))
     const twoDaysAgo = startOfDay(sub(now, { days: 2 }))
     jest.mocked(grabLock).mockResolvedValueOnce({
       lockSuccess: true,
-      lastSuccessfulRun: twoDaysAgo
+      lastSuccessfulRun: threeDaysAgo
     })
 
     const mockNewSession = /** @type {any} */ ({
@@ -165,10 +210,10 @@ describe('runMetricsCollectionJob', () => {
   })
 
   it('should log error if job fails', async () => {
-    const twoDaysAgo = startOfDay(sub(now, { days: 2 }))
+    const threeDaysAgo = startOfDay(sub(now, { days: 3 }))
     jest.mocked(grabLock).mockResolvedValueOnce({
       lockSuccess: true,
-      lastSuccessfulRun: twoDaysAgo
+      lastSuccessfulRun: threeDaysAgo
     })
     jest.mocked(getJson).mockImplementationOnce(() => {
       throw new Error('API JSON error')
@@ -469,50 +514,6 @@ describe('runMetricsCollectionJob', () => {
       const testDate = new Date('2026-04-01')
 
       jest.mocked(getNumberOfFormsInDraft).mockResolvedValueOnce(17)
-      const firstCreated = /** @type {AuditRecordInput[]} */ ([
-        {
-          type: 'FORM_CREATED',
-          entityId: 'form-id-1a',
-          createdAt: new Date('2026-03-30')
-        }
-      ])
-      const mockAsyncIteratorFirstCreated = {
-        [Symbol.asyncIterator]: function* () {
-          for (const metric of firstCreated) {
-            yield metric
-          }
-        }
-      }
-      const draftCreatedFromLive = /** @type {AuditRecordInput[]} */ ([
-        {
-          type: 'FORM_CREATED',
-          entityId: 'form-id-1a',
-          createdAt: new Date('2026-03-30')
-        }
-      ])
-      const mockAsyncIteratorDraftCreatedFromLive = {
-        [Symbol.asyncIterator]: function* () {
-          for (const metric of draftCreatedFromLive) {
-            yield metric
-          }
-        }
-      }
-
-      const firstPublished = /** @type {AuditRecordInput[]} */ ([
-        {
-          type: 'FORM_DRAFT_CREATED_FROM_LIVE',
-          entityId: 'form-id-1a',
-          createdAt: new Date('2026-04-08')
-        }
-      ])
-      const mockAsyncIteratorFirstPublished = {
-        [Symbol.asyncIterator]: function* () {
-          for (const metric of firstPublished) {
-            yield metric
-          }
-        }
-      }
-
       jest
         .mocked(getAuditRecordsOfType)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
@@ -731,14 +732,6 @@ describe('runMetricsCollectionJob', () => {
     })
   })
 
-  describe('setTimeOnDate', () => {
-    it('should set time on date', () => {
-      const testDateStr = '2026-02-05'
-      const expectedDate = new Date('2026-02-05T08:59:34.000Z')
-      expect(setTimeOnDate(testDateStr, expectedDate)).toEqual(expectedDate)
-    })
-  })
-
   describe('clearMetricsDatabase', () => {
     it('should clear db', async () => {
       jest.mocked(clearMetricsData).mockResolvedValueOnce()
@@ -751,6 +744,120 @@ describe('runMetricsCollectionJob', () => {
       jest.mocked(client.startSession).mockReturnValue(mockNewSession)
       await clearMetricsDatabase()
       expect(clearMetricsData).toHaveBeenCalled()
+    })
+  })
+
+  describe('collectMetrics', () => {
+    it('should skip if reporting is up-to-date', async () => {
+      const lastRunDate = new Date('2026-03-10T04:00:00.000Z')
+      const currentRunDate = new Date('2026-03-10T03:00:00.000Z')
+      const res = await collectMetrics(
+        currentRunDate,
+        lastRunDate,
+        30,
+        mockSession
+      )
+      expect(res).toEqual({
+        success: false,
+        message: 'Skipped',
+        endDate: undefined,
+        processMoreBatches: false
+      })
+    })
+
+    it('should loop if multiple days to report', async () => {
+      const lastRunDate = new Date('2026-03-06T04:00:00.000Z')
+      const currentRunDate = new Date('2026-03-10T03:00:00.000Z')
+
+      const mockNewSession = /** @type {any} */ ({
+        withTransaction: jest.fn().mockImplementation(async (callback) => {
+          return await callback()
+        }),
+        endSession: jest.fn().mockResolvedValue(undefined)
+      })
+      jest.mocked(client.startSession).mockReturnValue(mockNewSession)
+      jest
+        .mocked(getJson)
+        .mockResolvedValueOnce({ response: {}, body: { draft: {}, live: {} } })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
+
+      jest
+        .mocked(getAuditRecordsOfType)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+
+      const blankSet = /** @type {AuditRecordInput[]} */ ([])
+      const mockAsyncIteratorBlankSet = {
+        [Symbol.asyncIterator]: function* () {
+          for (const metric of blankSet) {
+            yield metric
+          }
+        }
+      }
+
+      jest
+        .mocked(getAllTimelineMetrics)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorBlankSet)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorBlankSet)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorBlankSet)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorBlankSet)
+
+      const res = await collectMetrics(
+        currentRunDate,
+        lastRunDate,
+        30,
+        mockSession
+      )
+
+      expect(res).toEqual({
+        success: true,
+        message: 'Completed ok',
+        endDate: new Date('2026-03-09T03:00:00.000Z'),
+        processMoreBatches: false
+      })
+      expect(getJson).toHaveBeenCalledTimes(4)
+      const calls = jest.mocked(getJson).mock.calls
+      expect(calls[0][0].href).toBe(
+        'http://localhost:3001/report/overview?date=2026-03-10T03:00:00.000Z'
+      )
+      expect(calls[1][0].href).toBe(
+        'http://localhost:3002/report/timeline?date=2026-03-07T04:00:00.000Z'
+      )
+      expect(calls[2][0].href).toBe(
+        'http://localhost:3002/report/timeline?date=2026-03-08T04:00:00.000Z'
+      )
+      expect(calls[3][0].href).toBe(
+        'http://localhost:3002/report/timeline?date=2026-03-09T04:00:00.000Z'
+      )
     })
   })
 })

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -6,6 +6,7 @@ import { getJson } from '~/src/lib/fetch.js'
 import { client } from '~/src/mongo.js'
 import { getAuditRecordsOfType } from '~/src/repositories/audit-record-repository.js'
 import {
+  clearMetricsData,
   getAllOverviewMetrics,
   getAllTimelineMetrics,
   getFirstDraft,
@@ -19,6 +20,7 @@ import {
 } from '~/src/repositories/metrics-repository.js'
 import {
   applyExtraColumns,
+  clearMetricsDatabase,
   collectManagerOverviewMetrics,
   collectTimelineMetrics,
   collectTimelineMetricsFromAudit,
@@ -26,6 +28,7 @@ import {
   recalcMetrics,
   runMetricsCollectionJob,
   setMetricTotal,
+  setTimeOnDate,
   updateMetricAverage,
   updateMetricTotal
 } from '~/src/service/metrics.js'
@@ -112,10 +115,10 @@ describe('runMetricsCollectionJob', () => {
   })
 
   it('should run job when able to lock', async () => {
-    const yesterday = startOfDay(sub(now, { days: 1 }))
+    const twoDaysAgo = startOfDay(sub(now, { days: 2 }))
     jest.mocked(grabLock).mockResolvedValueOnce({
       lockSuccess: true,
-      lastSuccessfulRun: yesterday
+      lastSuccessfulRun: twoDaysAgo
     })
 
     const mockNewSession = /** @type {any} */ ({
@@ -155,17 +158,17 @@ describe('runMetricsCollectionJob', () => {
     expect(getJson).toHaveBeenNthCalledWith(
       2,
       new URL(
-        'http://localhost:3002/report/timeline?date=' + yesterday.toISOString()
+        'http://localhost:3002/report/timeline?date=' + twoDaysAgo.toISOString()
       ),
       {}
     )
   })
 
   it('should log error if job fails', async () => {
-    const yesterday = startOfDay(sub(now, { days: 1 }))
+    const twoDaysAgo = startOfDay(sub(now, { days: 2 }))
     jest.mocked(grabLock).mockResolvedValueOnce({
       lockSuccess: true,
-      lastSuccessfulRun: yesterday
+      lastSuccessfulRun: twoDaysAgo
     })
     jest.mocked(getJson).mockImplementationOnce(() => {
       throw new Error('API JSON error')
@@ -182,8 +185,12 @@ describe('runMetricsCollectionJob', () => {
     await runMetricsCollectionJob()
 
     expect(releaseLock).toHaveBeenCalledWith(
-      false,
-      'API JSON error',
+      {
+        success: false,
+        message: 'API JSON error',
+        endDate: undefined,
+        processMoreBatches: false
+      },
       expect.anything()
     )
   })
@@ -721,6 +728,29 @@ describe('runMetricsCollectionJob', () => {
           summaryMetrics: { name: 'Form 2' }
         }
       ])
+    })
+  })
+
+  describe('setTimeOnDate', () => {
+    it('should set time on date', () => {
+      const testDateStr = '2026-02-05'
+      const expectedDate = new Date('2026-02-05T08:59:34.000Z')
+      expect(setTimeOnDate(testDateStr, expectedDate)).toEqual(expectedDate)
+    })
+  })
+
+  describe('clearMetricsDatabase', () => {
+    it('should clear db', async () => {
+      jest.mocked(clearMetricsData).mockResolvedValueOnce()
+      const mockNewSession = /** @type {any} */ ({
+        withTransaction: jest.fn().mockImplementation(async (callback) => {
+          return await callback()
+        }),
+        endSession: jest.fn().mockResolvedValue(undefined)
+      })
+      jest.mocked(client.startSession).mockReturnValue(mockNewSession)
+      await clearMetricsDatabase()
+      expect(clearMetricsData).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
To avoid transaction timeout issues, the metrics collection job now operates in small batches (one transaction epr batch). This should avoid any timeout issues.