### PR TITLE
fix/df-1096: Fixed publish counts being in wrong structure

### DIFF
--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -679,22 +679,24 @@ export function applyExtraColumns(metrics) {
 
   return metrics.overview.map((metric) => ({
     featureMetrics: metric.featureMetrics,
-    summaryMetrics: metric.summaryMetrics,
+    summaryMetrics: {
+      ...metric.summaryMetrics,
+      daysToPublish:
+        metric.formStatus === FormStatus.Live
+          ? (formDaysToPublish.get(metric.formId) ?? 0)
+          : undefined,
+      republished:
+        metric.formStatus === FormStatus.Live
+          ? (formRepublished.get(metric.formId) ?? 0)
+          : undefined
+    },
     formId: metric.formId,
     formName: metric.summaryMetrics.name,
     formStatus: metric.formStatus,
     submissionsCount:
       (metric.formStatus === FormStatus.Live
         ? submissionCountsLive.get(metric.formId)
-        : submissionCountsDraft.get(metric.formId)) ?? 0,
-    daysToPublish:
-      metric.formStatus === FormStatus.Live
-        ? (formDaysToPublish.get(metric.formId) ?? 0)
-        : undefined,
-    republished:
-      metric.formStatus === FormStatus.Live
-        ? (formRepublished.get(metric.formId) ?? 0)
-        : undefined
+        : submissionCountsDraft.get(metric.formId)) ?? 0
   }))
 }
 

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -662,14 +662,14 @@ describe('runMetricsCollectionJob', () => {
       expect(res).toEqual({
         overview: [
           {
-            daysToPublish: 0,
             formId: 'form-id-1',
             formName: 'Form 1',
             formStatus: 'live',
-            republished: 0,
             submissionsCount: 0,
             summaryMetrics: {
-              name: 'Form 1'
+              name: 'Form 1',
+              daysToPublish: 0,
+              republished: 0
             },
             featureMetrics: {}
           }
@@ -719,23 +719,27 @@ describe('runMetricsCollectionJob', () => {
       const res = applyExtraColumns(metrics)
       expect(res).toEqual([
         {
-          daysToPublish: 15,
           formId: 'form-id-1',
           formName: 'Form 1',
           formStatus: 'live',
-          republished: 2,
           submissionsCount: 5,
-          summaryMetrics: { name: 'Form 1' },
+          summaryMetrics: {
+            daysToPublish: 15,
+            republished: 2,
+            name: 'Form 1'
+          },
           featureMetrics: undefined
         },
         {
-          daysToPublish: undefined,
           formId: 'form-id-2',
           formName: 'Form 2',
           formStatus: 'draft',
-          republished: undefined,
           submissionsCount: 9,
-          summaryMetrics: { name: 'Form 2' },
+          summaryMetrics: {
+            daysToPublish: undefined,
+            republished: undefined,
+            name: 'Form 2'
+          },
           featureMetrics: undefined
         }
       ])


### PR DESCRIPTION
The counts for 'TimeToPublish' and 'Re-published' were being stored at wrong level in structures