### PR TITLE
fix/df-1104: Decodes search text (if escaped)

### DIFF
--- a/src/service/metrics-helper.js
+++ b/src/service/metrics-helper.js
@@ -87,5 +87,29 @@ export function getMetricCalcType(metric) {
 }
 
 /**
+ * Decode param list of encoded strings
+ * @param { string[] | undefined } params
+ */
+export function decodeParamList(params) {
+  // Decode param list (if applicable)
+  const paramsDecoded = /** @type {string[]} */ ([])
+  if (params) {
+    params.forEach((o) => paramsDecoded.push(decodeURI(o)))
+  }
+  return paramsDecoded.length ? paramsDecoded : undefined
+}
+
+/**
+ * @param {Record<string, number> | undefined} metricValues
+ */
+export function createFormMap(metricValues) {
+  const formMap = new Map()
+  for (const [formId, count] of Object.entries(metricValues ?? {})) {
+    formMap.set(formId, count)
+  }
+  return formMap
+}
+
+/**
  * @import { FormTimelineMetric } from '@defra/forms-model'
  */

--- a/src/service/metrics-helper.js
+++ b/src/service/metrics-helper.js
@@ -87,19 +87,6 @@ export function getMetricCalcType(metric) {
 }
 
 /**
- * Decode param list of encoded strings
- * @param { string[] | undefined } params
- */
-export function decodeParamList(params) {
-  // Decode param list (if applicable)
-  const paramsDecoded = /** @type {string[]} */ ([])
-  if (params) {
-    params.forEach((o) => paramsDecoded.push(decodeURI(o)))
-  }
-  return paramsDecoded.length ? paramsDecoded : undefined
-}
-
-/**
  * @param {Record<string, number> | undefined} metricValues
  */
 export function createFormMap(metricValues) {

--- a/src/service/metrics-helper.test.js
+++ b/src/service/metrics-helper.test.js
@@ -1,9 +1,24 @@
-import { setTimeOnDate } from '~/src/service/metrics-helper.js'
+import { decodeParamList, setTimeOnDate } from '~/src/service/metrics-helper.js'
 
-describe('setTimeOnDate', () => {
-  it('should set time on date', () => {
-    const testDateStr = '2026-02-05'
-    const expectedDate = new Date('2026-02-05T08:59:34.000Z')
-    expect(setTimeOnDate(testDateStr, expectedDate)).toEqual(expectedDate)
+describe('metrics-helper', () => {
+  describe('setTimeOnDate', () => {
+    it('should set time on date', () => {
+      const testDateStr = '2026-02-05'
+      const expectedDate = new Date('2026-02-05T08:59:34.000Z')
+      expect(setTimeOnDate(testDateStr, expectedDate)).toEqual(expectedDate)
+    })
+  })
+
+  describe('decodeParamList', () => {
+    it('should decode params', () => {
+      const params = ['abc%20def', 'def%20ghi']
+      const expectedParams = ['abc def', 'def ghi']
+      expect(decodeParamList(params)).toEqual(expectedParams)
+    })
+
+    it('should return undefined for no params', () => {
+      const params = /** @type {string[]} */ ([])
+      expect(decodeParamList(params)).toBeUndefined()
+    })
   })
 })

--- a/src/service/metrics-helper.test.js
+++ b/src/service/metrics-helper.test.js
@@ -1,4 +1,4 @@
-import { decodeParamList, setTimeOnDate } from '~/src/service/metrics-helper.js'
+import { setTimeOnDate } from '~/src/service/metrics-helper.js'
 
 describe('metrics-helper', () => {
   describe('setTimeOnDate', () => {
@@ -6,19 +6,6 @@ describe('metrics-helper', () => {
       const testDateStr = '2026-02-05'
       const expectedDate = new Date('2026-02-05T08:59:34.000Z')
       expect(setTimeOnDate(testDateStr, expectedDate)).toEqual(expectedDate)
-    })
-  })
-
-  describe('decodeParamList', () => {
-    it('should decode params', () => {
-      const params = ['abc%20def', 'def%20ghi']
-      const expectedParams = ['abc def', 'def ghi']
-      expect(decodeParamList(params)).toEqual(expectedParams)
-    })
-
-    it('should return undefined for no params', () => {
-      const params = /** @type {string[]} */ ([])
-      expect(decodeParamList(params)).toBeUndefined()
     })
   })
 })

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -38,7 +38,6 @@ import {
   CalculationTypes,
   createFormMap,
   dateFallsInsideTimeslot,
-  decodeParamList,
   formatDateOnly,
   getMetricCalcType,
   isDraftSubmission,
@@ -628,14 +627,6 @@ export async function generateReport(filter) {
   const session = client.startSession()
 
   try {
-    // Decode org list (if applicable)
-    filter.org = decodeParamList(filter.org)
-
-    // Decode searchText (if applicable)
-    if (filter.searchText) {
-      filter.searchText = decodeURI(filter.searchText)
-    }
-
     // Get raw metrics
     const overview = await getAllOverviewMetrics(filter, session).toArray()
     const totals = await getMetricTotals(session)

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -642,6 +642,11 @@ export async function generateReport(filter) {
     // Decode org list (if applicable)
     filter.org = decodeParamList(filter.org)
 
+    // Decode searchText (if applicable)
+    if (filter.searchText) {
+      filter.searchText = decodeURI(filter.searchText)
+    }
+
     // Get raw metrics
     const overview = await getAllOverviewMetrics(filter, session).toArray()
     const totals = await getMetricTotals(session)

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -36,7 +36,9 @@ import {
 } from '~/src/repositories/metrics-repository.js'
 import {
   CalculationTypes,
+  createFormMap,
   dateFallsInsideTimeslot,
+  decodeParamList,
   formatDateOnly,
   getMetricCalcType,
   isDraftSubmission,
@@ -619,19 +621,6 @@ export function decrementCountsForRepublish(map) {
 }
 
 /**
- * Decode param list of encoded strings
- * @param { string[] | undefined } params
- */
-export function decodeParamList(params) {
-  // Decode param list (if applicable)
-  const paramsDecoded = /** @type {string[]} */ ([])
-  if (params) {
-    params.forEach((o) => paramsDecoded.push(decodeURI(o)))
-  }
-  return paramsDecoded.length ? paramsDecoded : undefined
-}
-
-/**
  * Generates a report based on the stored metrics
  * @param {FilterCriteria} filter
  */
@@ -659,17 +648,6 @@ export async function generateReport(filter) {
   } finally {
     await session.endSession()
   }
-}
-
-/**
- * @param {Record<string, number> | undefined} metricValues
- */
-function createFormMap(metricValues) {
-  const formMap = new Map()
-  for (const [formId, count] of Object.entries(metricValues ?? {})) {
-    formMap.set(formId, count)
-  }
-  return formMap
 }
 
 /**

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -25,7 +25,6 @@ import {
   collectMetrics,
   collectTimelineMetrics,
   collectTimelineMetricsFromAudit,
-  decodeParamList,
   generateReport,
   recalcMetrics,
   runMetricsCollectionJob,
@@ -967,19 +966,6 @@ describe('runMetricsCollectionJob', () => {
       expect(calls[3][0].href).toBe(
         'http://localhost:3002/report/timeline?date=2026-03-09T04:00:00.000Z'
       )
-    })
-  })
-
-  describe('decodeParamList', () => {
-    it('should decode params', () => {
-      const params = ['abc%20def', 'def%20ghi']
-      const expectedParams = ['abc def', 'def ghi']
-      expect(decodeParamList(params)).toEqual(expectedParams)
-    })
-
-    it('should return undefined for no params', () => {
-      const params = /** @type {string[]} */ ([])
-      expect(decodeParamList(params)).toBeUndefined()
     })
   })
 })

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -703,7 +703,7 @@ describe('runMetricsCollectionJob', () => {
       })
       // @ts-expect-error - partial data mock
       jest.mocked(getMetricTotals).mockResolvedValueOnce([])
-      await generateReport({ searchText: 'abc%20def', org: ['org%201'] })
+      await generateReport({ searchText: 'abc def', org: ['org 1'] })
       expect(getAllOverviewMetrics).toHaveBeenCalledWith(
         {
           org: ['org 1'],

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -676,6 +676,42 @@ describe('runMetricsCollectionJob', () => {
         totals: []
       })
     })
+
+    it('should generate report using filter criteria', async () => {
+      const mockNewSession = /** @type {any} */ ({
+        endSession: jest.fn().mockResolvedValue(undefined)
+      })
+      jest.mocked(client.startSession).mockReturnValue(mockNewSession)
+
+      const overviewMetrics = /** @type {WithId<FormOverviewMetric>[]} */ ([
+        {
+          _id: new ObjectId('69fb0727de574045cd8c0b0e'),
+          type: FormMetricType.OverviewMetric,
+          formId: 'form-id-1',
+          formStatus: FormStatus.Live,
+          summaryMetrics: {
+            name: 'Form 1'
+          },
+          featureMetrics: {},
+          submissionsCount: 5,
+          updatedAt: new Date('2026-02-02')
+        }
+      ])
+      jest.mocked(getAllOverviewMetrics).mockReturnValueOnce({
+        // @ts-expect-error - partial data mock
+        toArray: () => overviewMetrics
+      })
+      // @ts-expect-error - partial data mock
+      jest.mocked(getMetricTotals).mockResolvedValueOnce([])
+      await generateReport({ searchText: 'abc%20def', org: ['org%201'] })
+      expect(getAllOverviewMetrics).toHaveBeenCalledWith(
+        {
+          org: ['org 1'],
+          searchText: 'abc def'
+        },
+        expect.anything()
+      )
+    })
   })
 
   describe('applyExtraColumns', () => {


### PR DESCRIPTION
Fix to handle search text in a metric query that may contain spaces e.g. 'shark fin'