### PR TITLE
feat/df-1137: Save drilldown detail as separate records

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@aws-sdk/client-sqs": "3.1052.0",
         "@defra/cdp-auditing": "0.6.0",
-        "@defra/forms-model": "3.0.673",
+        "@defra/forms-model": "3.0.675",
         "@defra/hapi-tracing": "^1.26.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.4.6",
@@ -483,11 +483,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -533,12 +535,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -625,7 +629,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -645,25 +651,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -684,9 +694,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -738,7 +748,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -746,7 +758,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -787,11 +801,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1495,14 +1511,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1974,29 +1992,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2004,12 +2026,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2075,9 +2099,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.673",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.673.tgz",
-      "integrity": "sha512-CyPKSpnWYv+mBhZXNjc2L2mNxrzuGp3iToxHbzv3QU8ckmPUbocS6jgB7rXsgg98Fvza7hiG7CCCRG3wUwyCbg==",
+      "version": "3.0.675",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.675.tgz",
+      "integrity": "sha512-78j5PrvUFaRYT5u4nsdxd8MizJqCaEarHIuPd5qTr/0PwS5j5Au0oT1wmWwki+9trkfz6it/r8kVXHL+/Zfwjw==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",
@@ -2888,9 +2912,9 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.1.tgz",
-      "integrity": "sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.2.tgz",
+      "integrity": "sha512-OKyCOTjNR1hftwSjk9ueyAQTw8AwapvzBrPIWMGn39vhR5PmqLdYFmLc35bsSBye7gSMnlkXfc679bUdMIcRyQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.0"
@@ -3107,7 +3131,9 @@
       }
     },
     "node_modules/@hapi/wreck": {
-      "version": "18.1.0",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.2.tgz",
+      "integrity": "sha512-3dMnV2pfhQiyEqu8DL3VBmxkdLiRDiiUDuG79Dp+UK1gL9ZxAfDOUhB6k3D5MLqcgJJ1IARyGFhwoc1NITr/pg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
@@ -4466,7 +4492,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5427,9 +5455,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -7854,19 +7882,13 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "license": "BSD-3-Clause"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -9226,10 +9248,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "license": "MIT"
     },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.1.0",
@@ -11382,10 +11400,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.6",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -12291,9 +12311,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "3.1052.0",
     "@defra/cdp-auditing": "0.6.0",
-    "@defra/forms-model": "3.0.673",
+    "@defra/forms-model": "3.0.675",
     "@defra/hapi-tracing": "^1.26.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.4.6",

--- a/src/mongo.js
+++ b/src/mongo.js
@@ -47,13 +47,8 @@ export async function prepareDb(logger) {
 
   const coll2 = db.collection(METRICS_COLLECTION_NAME)
 
-  await coll2.createIndex({
-    type: 1,
-    formId: 1,
-    metricName: 1,
-    periodName: 1,
-    formStatus: 1
-  })
+  await coll2.createIndex({ type: 1, formId: 1, metricName: 1, formStatus: 1 })
+  await coll2.createIndex({ type: 1, metricName: 1, periodName: 1 })
 
   logger.info(`Mongodb connected to ${databaseName}`)
 

--- a/src/mongo.js
+++ b/src/mongo.js
@@ -47,7 +47,13 @@ export async function prepareDb(logger) {
 
   const coll2 = db.collection(METRICS_COLLECTION_NAME)
 
-  await coll2.createIndex({ type: 1, formId: 1, metricName: 1, formStatus: 1 })
+  await coll2.createIndex({
+    type: 1,
+    formId: 1,
+    metricName: 1,
+    periodName: 1,
+    formStatus: 1
+  })
 
   logger.info(`Mongodb connected to ${databaseName}`)
 

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -375,18 +375,20 @@ export async function saveDrilldownRecords(
 ) {
   const coll = getMetricCollection()
 
+  if (details.length === 0) {
+    return
+  }
+
   try {
-    for (const detail of details) {
-      await coll.insertOne(
-        {
-          ...detail,
-          metricName,
-          periodName,
-          type: FormMetricType.DrilldownMetric
-        },
-        { session }
-      )
-    }
+    await coll.insertMany(
+      details.map((detail) => ({
+        ...detail,
+        metricName,
+        periodName,
+        type: FormMetricType.DrilldownMetric
+      })),
+      { session }
+    )
   } catch (err) {
     logger.error(
       err,

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -3,26 +3,16 @@ import { FormMetricName, FormMetricType, FormStatus } from '@defra/forms-model'
 import { getErrorMessage } from '~/src/helpers/error-message.js'
 import { logger } from '~/src/helpers/logging/logger.js'
 import { METRICS_COLLECTION_NAME, db } from '~/src/mongo.js'
+import { metricDrilldownPeriods } from '~/src/service/metrics-helper.js'
 
 const FORM_METRIC_CONTROL = 'form-metric-control'
 
 /**
- * @typedef {object} FormMetricControl
- * @property {string} type - type of record
- * @property {boolean} locked - true if locked i.e. a container is already running the job
- * @property {Date} jobStart - timestamp for when the job started
- * @property { Date | null } jobEnd - timestamp for when the job ended
- * @property { Date | null } lastSuccessfulRunDate - timestamp for when the last successful run started
- * @property {string} lastRunResult - outcome of last run
- * @property {Date} updatedAt - last updated timestamp
- */
-
-/**
  * Gets the metric collection
- * @returns {Collection<FormOverviewMetric | FormTimelineMetric | FormTotalsMetric | FormMetricControl>}
+ * @returns {Collection<FormOverviewMetric | FormTimelineMetric | FormTotalsMetric | FormDrilldownMetric | FormMetricControl>}
  */
 function getMetricCollection() {
-  return /** @type {Collection<FormOverviewMetric | FormTimelineMetric | FormTotalsMetric | FormMetricControl>} */ (
+  return /** @type {Collection<FormOverviewMetric | FormTimelineMetric | FormTotalsMetric | FormDrilldownMetric | FormMetricControl>} */ (
     db.collection(METRICS_COLLECTION_NAME)
   )
 }
@@ -233,40 +223,6 @@ export function getAllTimelineMetrics(session) {
 }
 
 /**
- * Get all timeline metrics for a particular metric name and formId
- * @param {string} metricName
- * @param {string} formId
- * @param {ClientSession} session
- * @returns {Promise<WithId<FormTimelineMetric>[]>}
- */
-export async function getTimelineMetricsForMetricName(
-  metricName,
-  formId,
-  session
-) {
-  const coll = getMetricCollection()
-
-  try {
-    const timelineRecords =
-      /** @type {FindCursor<WithId<FormTimelineMetric>>} */ (
-        coll
-          .find(
-            { type: FormMetricType.TimelineMetric, metricName, formId },
-            { session }
-          )
-          .sort({ createdAt: -1 })
-      )
-    return await timelineRecords.toArray()
-  } catch (err) {
-    logger.error(
-      err,
-      `Failed to read timeline metric for metric ${metricName} and form id ${formId} - ${getErrorMessage(err)}`
-    )
-    throw err
-  }
-}
-
-/**
  * Saves snapshot metric records for a form.
  * @param {string} formId
  * @param {FormTimelineMetric} metricData
@@ -311,6 +267,37 @@ export function getMetricTotals(session) {
 }
 
 /**
+ * Gets metric drilldown records.
+ * @param {string} periodName
+ * @param {FormMetricName} metricName
+ * @param {ClientSession} session
+ */
+export async function getDrilldownRecords(periodName, metricName, session) {
+  const coll = getMetricCollection()
+
+  try {
+    return await /** @type {Promise<WithId<FormDrilldownMetric>[]>} */ (
+      coll
+        .find(
+          {
+            type: FormMetricType.DrilldownMetric,
+            periodName,
+            metricName
+          },
+          { session }
+        )
+        .toArray()
+    )
+  } catch (err) {
+    logger.error(
+      err,
+      `Failed to get drilldown metrics - ${getErrorMessage(err)}`
+    )
+    throw err
+  }
+}
+
+/**
  * Saves snapshot metric records for a form.
  * @param {Date} reportDate
  * @param {FormTotalsMetric} totals
@@ -320,8 +307,14 @@ export async function updateMetricTotals(reportDate, totals, session) {
   const coll = getMetricCollection()
 
   try {
-    totals.updatedAt = reportDate
     await coll.deleteMany({ type: FormMetricType.TotalsMetric }, { session })
+    await coll.deleteMany({ type: FormMetricType.DrilldownMetric }, { session })
+
+    // Extract drilldown detail from 'totals' data, and save as drilldown records
+    totals = await saveDrilldown(totals, session)
+    totals.updatedAt = reportDate
+
+    // Now save 'totals' records with drilldown data removed
     await coll.insertOne(
       {
         ...totals,
@@ -331,6 +324,74 @@ export async function updateMetricTotals(reportDate, totals, session) {
     )
   } catch (err) {
     logger.error(err, `Failed to save totals metric - ${getErrorMessage(err)}`)
+    throw err
+  }
+}
+
+/**
+ * Saves drilldown details.
+ * @param {FormTotalsMetric} totals
+ * @param {ClientSession} session
+ */
+export async function saveDrilldown(totals, session) {
+  for (const periodName of metricDrilldownPeriods) {
+    // @ts-expect-error - dynamic lookup
+    const period = totals[periodName]
+    if (!period) {
+      continue
+    }
+
+    for (const metricName of Object.keys(period)) {
+      const detail = period[metricName]
+      if ('details' in detail) {
+        const details = /** @type {FormDrilldownMetric[]} */ (detail.details)
+        await saveDrilldownRecords(
+          periodName,
+          /** @type {FormMetricName} */ (metricName),
+          details,
+          session
+        )
+        // @ts-expect-error - dynamic lookup
+        delete totals[periodName][metricName].details
+      }
+    }
+  }
+
+  return totals
+}
+
+/**
+ * Saves drilldown metric records.
+ * @param {string} periodName
+ * @param {FormMetricName} metricName
+ * @param {FormDrilldownMetric[]} details
+ * @param {ClientSession} session
+ */
+export async function saveDrilldownRecords(
+  periodName,
+  metricName,
+  details,
+  session
+) {
+  const coll = getMetricCollection()
+
+  try {
+    for (const detail of details) {
+      await coll.insertOne(
+        {
+          ...detail,
+          metricName,
+          periodName,
+          type: FormMetricType.DrilldownMetric
+        },
+        { session }
+      )
+    }
+  } catch (err) {
+    logger.error(
+      err,
+      `Failed to save drilldown metric record - period: ${periodName} metricName: ${metricName} ${getErrorMessage(err)}`
+    )
     throw err
   }
 }
@@ -577,6 +638,6 @@ export async function clearMetricsData(session) {
 
 /**
  * @import { ClientSession, Collection, FindCursor, WithId } from 'mongodb'
- * @import { FormOverviewMetric, FormTimelineMetric, FormTotalsMetric } from '@defra/forms-model'
- * @import { FilterCriteria } from '~/src/service/metrics.js'
+ * @import { FormOverviewMetric, FormTimelineMetric, FormTotalsMetric, FormDrilldownMetric } from '@defra/forms-model'
+ * @import { FilterCriteria, FormMetricControl } from '~/src/service/metrics.js'
  */

--- a/src/repositories/metrics-repository.test.js
+++ b/src/repositories/metrics-repository.test.js
@@ -780,8 +780,8 @@ describe('metrics-repository', () => {
       mockCollection.insertMany.mockImplementationOnce(() => {
         throw new Error('bad db call')
       })
-      // @ts-expect-error - partial mock of data
       await expect(() =>
+        // @ts-expect-error - partial mock of data
         saveDrilldown(totalsCopy, mockSession)
       ).rejects.toThrow('bad db call')
     })

--- a/src/repositories/metrics-repository.test.js
+++ b/src/repositories/metrics-repository.test.js
@@ -691,96 +691,99 @@ describe('metrics-repository', () => {
   })
 
   describe('saveDrilldown', () => {
-    it('should save a batch of drilldown records', async () => {
-      const totals = {
-        last7Days: {
-          NewFormsCreated: {
-            count: 2,
-            details: [
-              {
-                formId: 'form-id-1',
-                createdAt: new Date('2026-01-01T14:00:00.000Z'),
-                metricValue: 1
-              },
-              {
-                formId: 'form-id-2',
-                createdAt: new Date('2026-01-02T14:00:00.000Z'),
-                metricValue: 1
-              }
-            ]
-          },
-          NoDetails: {
-            count: 17
-          }
+    const totals = {
+      last7Days: {
+        NewFormsCreated: {
+          count: 2,
+          details: [
+            {
+              formId: 'form-id-1',
+              createdAt: new Date('2026-01-01T14:00:00.000Z'),
+              metricValue: 1
+            },
+            {
+              formId: 'form-id-2',
+              createdAt: new Date('2026-01-02T14:00:00.000Z'),
+              metricValue: 1
+            }
+          ]
         },
-        last30Days: {
-          NewFormsCreated: {
-            count: 3,
-            details: [
-              {
-                formId: 'form-id-1',
-                createdAt: new Date('2026-01-01T14:00:00.000Z'),
-                metricValue: 1
-              },
-              {
-                formId: 'form-id-2',
-                createdAt: new Date('2026-01-02T14:00:00.000Z'),
-                metricValue: 1
-              },
-              {
-                formId: 'form-id-3',
-                createdAt: new Date('2025-12-02T14:00:00.000Z'),
-                metricValue: 1
-              }
-            ]
-          }
-        },
-        allTime: {
-          NewFormsCreated: {
-            count: 5,
-            details: [
-              {
-                formId: 'form-id-1',
-                createdAt: new Date('2026-01-01T14:00:00.000Z'),
-                metricValue: 1
-              },
-              {
-                formId: 'form-id-2',
-                createdAt: new Date('2026-01-02T14:00:00.000Z'),
-                metricValue: 1
-              },
-              {
-                formId: 'form-id-3',
-                createdAt: new Date('2025-12-02T14:00:00.000Z'),
-                metricValue: 1
-              },
-              {
-                formId: 'form-id-4',
-                createdAt: new Date('2025-11-02T14:00:00.000Z'),
-                metricValue: 1
-              },
-              {
-                formId: 'form-id-5',
-                createdAt: new Date('2025-10-02T14:00:00.000Z'),
-                metricValue: 1
-              }
-            ]
-          }
+        NoDetails: {
+          count: 17
+        }
+      },
+      last30Days: {
+        NewFormsCreated: {
+          count: 3,
+          details: [
+            {
+              formId: 'form-id-1',
+              createdAt: new Date('2026-01-01T14:00:00.000Z'),
+              metricValue: 1
+            },
+            {
+              formId: 'form-id-2',
+              createdAt: new Date('2026-01-02T14:00:00.000Z'),
+              metricValue: 1
+            },
+            {
+              formId: 'form-id-3',
+              createdAt: new Date('2025-12-02T14:00:00.000Z'),
+              metricValue: 1
+            }
+          ]
+        }
+      },
+      allTime: {
+        NewFormsCreated: {
+          count: 5,
+          details: [
+            {
+              formId: 'form-id-1',
+              createdAt: new Date('2026-01-01T14:00:00.000Z'),
+              metricValue: 1
+            },
+            {
+              formId: 'form-id-2',
+              createdAt: new Date('2026-01-02T14:00:00.000Z'),
+              metricValue: 1
+            },
+            {
+              formId: 'form-id-3',
+              createdAt: new Date('2025-12-02T14:00:00.000Z'),
+              metricValue: 1
+            },
+            {
+              formId: 'form-id-4',
+              createdAt: new Date('2025-11-02T14:00:00.000Z'),
+              metricValue: 1
+            },
+            {
+              formId: 'form-id-5',
+              createdAt: new Date('2025-10-02T14:00:00.000Z'),
+              metricValue: 1
+            }
+          ]
         }
       }
+    }
+    it('should save a batch of drilldown records', async () => {
+      const totalsCopy = structuredClone(totals)
       // @ts-expect-error - partial mock of data
-      await saveDrilldown(totals, mockSession)
+      await saveDrilldown(totalsCopy, mockSession)
 
-      expect(mockCollection.insertOne).toHaveBeenCalledTimes(10)
+      expect(mockCollection.insertMany).toHaveBeenCalledTimes(3)
     })
 
     it('should throw if error', async () => {
-      mockCollection.deleteMany.mockImplementationOnce(() => {
+      const totalsCopy = structuredClone(totals)
+      mockCollection.insertMany.mockImplementationOnce(() => {
         throw new Error('bad db call')
       })
-      await expect(() => clearMetricsData(mockSession)).rejects.toThrow(
-        'bad db call'
-      )
+      // @ts-expect-error - partial mock of data
+      await expect(() =>
+        saveDrilldown(totalsCopy, mockSession)
+      ).rejects.toThrow('bad db call')
     })
   })
 
@@ -795,11 +798,11 @@ describe('metrics-repository', () => {
         details,
         mockSession
       )
-      expect(mockCollection.insertOne).toHaveBeenCalledTimes(3)
+      expect(mockCollection.insertMany).toHaveBeenCalledTimes(1)
     })
 
     it('should throw if error', async () => {
-      mockCollection.insertOne.mockImplementationOnce(() => {
+      mockCollection.insertMany.mockImplementationOnce(() => {
         throw new Error('bad db call')
       })
       await expect(() =>

--- a/src/repositories/metrics-repository.test.js
+++ b/src/repositories/metrics-repository.test.js
@@ -7,15 +7,17 @@ import {
   deleteFormOverviewMetrics,
   getAllOverviewMetrics,
   getAllTimelineMetrics,
+  getDrilldownRecords,
   getFirstDraft,
   getFormOverviewMetrics,
   getFormTimelineMetrics,
   getMetricTotals,
   getNumberOfFormsInDraft,
-  getTimelineMetricsForMetricName,
   grabLock,
   isFirstPublish,
   releaseLock,
+  saveDrilldown,
+  saveDrilldownRecords,
   saveFormOverviewMetrics,
   saveFormTimelineMetrics,
   updateMetricTotals
@@ -497,40 +499,6 @@ describe('metrics-repository', () => {
     })
   })
 
-  describe('getTimelineMetricsForMetricName', () => {
-    it('should get records for specific formId and metric name', async () => {
-      mockCollection.find.mockReturnValueOnce({
-        sort: jest.fn(() => {
-          return { toArray: () => [] }
-        })
-      })
-      await getTimelineMetricsForMetricName(
-        'metric-name',
-        'form-id',
-        mockSession
-      )
-      expect(mockCollection.find).toHaveBeenCalledWith(
-        {
-          type: FormMetricType.TimelineMetric,
-          metricName: 'metric-name',
-          formId: 'form-id'
-        },
-        { session: {} }
-      )
-    })
-
-    it('should throw if error', async () => {
-      mockCollection.find.mockReturnValueOnce({
-        sort: () => {
-          throw new Error('bad db call passing metric name')
-        }
-      })
-      await expect(() =>
-        getTimelineMetricsForMetricName('metric-name', 'form-id', mockSession)
-      ).rejects.toThrow('bad db call passing metric name')
-    })
-  })
-
   describe('isFirstPublish', () => {
     it('should return true if one or fewer records', async () => {
       mockCollection.findOne.mockReturnValueOnce(null)
@@ -617,6 +585,41 @@ describe('metrics-repository', () => {
     })
   })
 
+  describe('getDrilldownRecords', () => {
+    it('should return records', async () => {
+      mockCollection.find.mockReturnValueOnce({
+        toArray: () => [{ drill1: 123 }, { drill2: 456 }]
+      })
+      const res = await getDrilldownRecords(
+        'last7Days',
+        FormMetricName.NewFormsCreated,
+        mockSession
+      )
+      expect(res).toEqual([{ drill1: 123 }, { drill2: 456 }])
+      expect(mockCollection.find).toHaveBeenCalledWith(
+        {
+          type: FormMetricType.DrilldownMetric,
+          metricName: FormMetricName.NewFormsCreated,
+          periodName: 'last7Days'
+        },
+        { session: {} }
+      )
+    })
+
+    it('should throw if error', async () => {
+      mockCollection.find.mockImplementationOnce(() => {
+        throw new Error('bad db call')
+      })
+      await expect(() =>
+        getDrilldownRecords(
+          'last7Days',
+          FormMetricName.NewFormsCreated,
+          mockSession
+        )
+      ).rejects.toThrow('bad db call')
+    })
+  })
+
   describe('getNumberOfFormsInDraft', () => {
     const testDate = new Date('2026-04-01')
 
@@ -684,6 +687,130 @@ describe('metrics-repository', () => {
       await expect(() => clearMetricsData(mockSession)).rejects.toThrow(
         'bad db call'
       )
+    })
+  })
+
+  describe('saveDrilldown', () => {
+    it('should save a batch of drilldown records', async () => {
+      const totals = {
+        last7Days: {
+          NewFormsCreated: {
+            count: 2,
+            details: [
+              {
+                formId: 'form-id-1',
+                createdAt: new Date('2026-01-01T14:00:00.000Z'),
+                metricValue: 1
+              },
+              {
+                formId: 'form-id-2',
+                createdAt: new Date('2026-01-02T14:00:00.000Z'),
+                metricValue: 1
+              }
+            ]
+          },
+          NoDetails: {
+            count: 17
+          }
+        },
+        last30Days: {
+          NewFormsCreated: {
+            count: 3,
+            details: [
+              {
+                formId: 'form-id-1',
+                createdAt: new Date('2026-01-01T14:00:00.000Z'),
+                metricValue: 1
+              },
+              {
+                formId: 'form-id-2',
+                createdAt: new Date('2026-01-02T14:00:00.000Z'),
+                metricValue: 1
+              },
+              {
+                formId: 'form-id-3',
+                createdAt: new Date('2025-12-02T14:00:00.000Z'),
+                metricValue: 1
+              }
+            ]
+          }
+        },
+        allTime: {
+          NewFormsCreated: {
+            count: 5,
+            details: [
+              {
+                formId: 'form-id-1',
+                createdAt: new Date('2026-01-01T14:00:00.000Z'),
+                metricValue: 1
+              },
+              {
+                formId: 'form-id-2',
+                createdAt: new Date('2026-01-02T14:00:00.000Z'),
+                metricValue: 1
+              },
+              {
+                formId: 'form-id-3',
+                createdAt: new Date('2025-12-02T14:00:00.000Z'),
+                metricValue: 1
+              },
+              {
+                formId: 'form-id-4',
+                createdAt: new Date('2025-11-02T14:00:00.000Z'),
+                metricValue: 1
+              },
+              {
+                formId: 'form-id-5',
+                createdAt: new Date('2025-10-02T14:00:00.000Z'),
+                metricValue: 1
+              }
+            ]
+          }
+        }
+      }
+      // @ts-expect-error - partial mock of data
+      await saveDrilldown(totals, mockSession)
+
+      expect(mockCollection.insertOne).toHaveBeenCalledTimes(10)
+    })
+
+    it('should throw if error', async () => {
+      mockCollection.deleteMany.mockImplementationOnce(() => {
+        throw new Error('bad db call')
+      })
+      await expect(() => clearMetricsData(mockSession)).rejects.toThrow(
+        'bad db call'
+      )
+    })
+  })
+
+  describe('saveDrilldownRecords', () => {
+    const details = [{ detail: '1' }, { detail: '2' }, { detail: '3' }]
+
+    it('should save batch of records', async () => {
+      await saveDrilldownRecords(
+        'last7Days',
+        FormMetricName.NewFormsCreated,
+        // @ts-expect-error - partial mock of data
+        details,
+        mockSession
+      )
+      expect(mockCollection.insertOne).toHaveBeenCalledTimes(3)
+    })
+
+    it('should throw if error', async () => {
+      mockCollection.insertOne.mockImplementationOnce(() => {
+        throw new Error('bad db call')
+      })
+      await expect(() =>
+        saveDrilldownRecords(
+          'last7Days',
+          FormMetricName.NewFormsCreated,
+          // @ts-expect-error - partial mock of data
+          details,
+          mockSession
+        )
+      ).rejects.toThrow('bad db call')
     })
   })
 })

--- a/src/routes/report.js
+++ b/src/routes/report.js
@@ -1,9 +1,10 @@
-import { Scopes } from '@defra/forms-model'
+import { FormMetricName, Scopes } from '@defra/forms-model'
 import Joi from 'joi'
 
 import { runMetricsCollectionJob } from '~/src/service/metrics-job.js'
 import {
   clearMetricsDatabase,
+  generateDrilldownReport,
   generateReport,
   generateReportForForm
 } from '~/src/service/metrics.js'
@@ -21,6 +22,13 @@ const filteringSchema = Joi.object({
 
 const paramSchema = Joi.object({
   formId: Joi.string().required()
+})
+
+const drilldownSchema = Joi.object({
+  period: Joi.string().valid('last7Days', 'last30Days', 'allTime').required(),
+  metricName: Joi.string()
+    .valid(...Object.values(FormMetricName))
+    .required()
 })
 
 export default [
@@ -60,6 +68,29 @@ export default [
       auth: false,
       validate: {
         params: paramSchema
+      }
+    }
+  }),
+
+  /**
+   * @satisfies {ServerRoute<{ Params: { period: string, metricName: FormMetricName } }>}
+   */
+  ({
+    method: 'GET',
+    path: '/report/{period}/{metricName}',
+    async handler(request, h) {
+      const { params } = request
+      const metrics = await generateDrilldownReport(
+        params.period,
+        params.metricName
+      )
+
+      return h.response(metrics).code(HTTP_OK)
+    },
+    options: {
+      auth: false,
+      validate: {
+        params: drilldownSchema
       }
     }
   }),

--- a/src/routes/report.test.js
+++ b/src/routes/report.test.js
@@ -1,6 +1,10 @@
 import { createServer } from '~/src/api/server.js'
 import { runMetricsCollectionJob } from '~/src/service/metrics-job.js'
-import { generateReport, generateReportForForm } from '~/src/service/metrics.js'
+import {
+  generateDrilldownReport,
+  generateReport,
+  generateReportForForm
+} from '~/src/service/metrics.js'
 import { authSuperAdmin as auth } from '~/test/fixtures/auth.js'
 
 jest.mock('~/src/service/metrics.js')
@@ -40,6 +44,23 @@ describe('Report routes', () => {
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
       expect(response.result).toEqual({ overview: [], totals: null })
+    })
+
+    test('/report/period/metricName route returns 200', async () => {
+      jest
+        .mocked(generateDrilldownReport)
+        // @ts-expect-error - partial data mock
+        .mockResolvedValue([])
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/report/last7Days/NewFormsCreated',
+        auth
+      })
+
+      expect(response.statusCode).toEqual(okStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+      expect(response.result).toEqual([])
     })
 
     test('/report/form-id route returns 200', async () => {

--- a/src/service/metrics-helper.js
+++ b/src/service/metrics-helper.js
@@ -30,6 +30,8 @@ export const metricConfig =
     }
   }
 
+export const metricDrilldownPeriods = ['last7Days', 'last30Days', 'allTime']
+
 /**
  * @typedef {object} CollectionJobResult
  * @property {boolean} success - true if job was successful

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -23,6 +23,7 @@ import {
   deleteFormOverviewMetrics,
   getAllOverviewMetrics,
   getAllTimelineMetrics,
+  getDrilldownRecords,
   getFirstDraft,
   getFormTimelineMetricsCursor,
   getMetricTotals,
@@ -48,6 +49,17 @@ import {
  * @property {string} [searchText] - text to search within a form name
  * @property {string[]} [status] - array of statuses
  * @property {string[]} [org] - arrays of organisations
+ */
+
+/**
+ * @typedef {object} FormMetricControl
+ * @property {string} type - type of record
+ * @property {boolean} locked - true if locked i.e. a container is already running the job
+ * @property {Date} jobStart - timestamp for when the job started
+ * @property { Date | null } jobEnd - timestamp for when the job ended
+ * @property { Date | null } lastSuccessfulRunDate - timestamp for when the last successful run started
+ * @property {string} lastRunResult - outcome of last run
+ * @property {Date} updatedAt - last updated timestamp
  */
 
 const managerUrl = config.get('managerUrl')
@@ -303,10 +315,16 @@ export async function collectTimelineMetricsFromAudit(reportingDate, session) {
  * @param {FormTimelineMetric} metric
  * @param { Record<string, { count?: number }> | undefined } period
  * @param {string} calculationType
+ * @param {boolean} [saveDrilldown]
  */
-export function handleMetricValue(metric, period, calculationType) {
+export function handleMetricValue(
+  metric,
+  period,
+  calculationType,
+  saveDrilldown
+) {
   if (calculationType === CalculationTypes.AccumulationWithDrilldown) {
-    updateMetricTotal(metric, period, true)
+    updateMetricTotal(metric, period, saveDrilldown)
   }
   if (calculationType === CalculationTypes.Accumulation) {
     updateMetricTotal(metric, period)
@@ -466,7 +484,7 @@ export async function recalcMetrics(reportingDate, session, formId) {
     const createdAt = new Date(metric.createdAt)
     // Last 7 days
     // prettier-ignore
-    handleTimeslot(metric, totals.last7Days, metricCalcType, createdAt, sevenDaysAgo, reportMorning)
+    handleTimeslot(metric, totals.last7Days, metricCalcType, createdAt, sevenDaysAgo, reportMorning, true)
 
     // Previous 7 days
     // prettier-ignore
@@ -474,7 +492,7 @@ export async function recalcMetrics(reportingDate, session, formId) {
 
     // Last 30 days
     // prettier-ignore
-    handleTimeslot(metric, totals.last30Days, metricCalcType, createdAt, thirtyDaysAgo, reportMorning)
+    handleTimeslot(metric, totals.last30Days, metricCalcType, createdAt, thirtyDaysAgo, reportMorning, true)
 
     // Previous 30 days
     // prettier-ignore
@@ -489,7 +507,7 @@ export async function recalcMetrics(reportingDate, session, formId) {
     handleTimeslot(metric, totals.prevYear, metricCalcType, createdAt, twoYearsAgo, oneYearAgo)
 
     // All time
-    handleMetricValue(metric, totals.allTime, metricCalcType)
+    handleMetricValue(metric, totals.allTime, metricCalcType, true)
   }
   totals.liveSubmissions = Object.fromEntries(maps.formSubmissionsMapLive)
   totals.draftSubmissions = Object.fromEntries(maps.formSubmissionsMapDraft)
@@ -530,6 +548,7 @@ function handleDraftSubmissions(metric, map) {
  * @param {Date} createdAt
  * @param {Date} startOfSlot
  * @param {Date} endOfSlot
+ * @param {boolean} [saveDrilldown]
  */
 function handleTimeslot(
   metric,
@@ -537,10 +556,11 @@ function handleTimeslot(
   metricCalcType,
   createdAt,
   startOfSlot,
-  endOfSlot
+  endOfSlot,
+  saveDrilldown
 ) {
   if (dateFallsInsideTimeslot(createdAt, startOfSlot, endOfSlot)) {
-    handleMetricValue(metric, period, metricCalcType)
+    handleMetricValue(metric, period, metricCalcType, saveDrilldown)
   }
 }
 
@@ -639,6 +659,24 @@ export async function generateReportForForm(formId) {
 
     return {
       totals
+    }
+  } finally {
+    await session.endSession()
+  }
+}
+
+/**
+ * Generates a drilldown report (sub-details of a tile)
+ * @param {string} period
+ * @param {FormMetricName} metricName
+ */
+export async function generateDrilldownReport(period, metricName) {
+  const session = client.startSession()
+
+  try {
+    const drilldownRows = await getDrilldownRecords(period, metricName, session)
+    return {
+      drilldownRows
     }
   } finally {
     await session.endSession()

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -9,6 +9,7 @@ import {
   clearMetricsData,
   getAllOverviewMetrics,
   getAllTimelineMetrics,
+  getDrilldownRecords,
   getFirstDraft,
   getFormTimelineMetricsCursor,
   getMetricTotals,
@@ -27,6 +28,7 @@ import {
   collectMetrics,
   collectTimelineMetrics,
   collectTimelineMetricsFromAudit,
+  generateDrilldownReport,
   generateReport,
   generateReportForForm,
   getOverviewMetricsForForms,
@@ -504,9 +506,6 @@ describe('runMetricsCollectionJob', () => {
           count: 6
         }
       })
-      expect(totals.prev7Days?.NewFormsCreated.details).toHaveLength(2)
-      // Remove 'details' attributes for comparison
-      delete totals.prev7Days?.NewFormsCreated.details
       expect(totals.prev7Days).toEqual({
         NewFormsCreated: {
           count: 9
@@ -525,11 +524,6 @@ describe('runMetricsCollectionJob', () => {
           count: 6
         }
       })
-      expect(totals.prev30Days?.NewFormsCreated.details).toHaveLength(2)
-      expect(totals.prev30Days?.Submissions.details).toHaveLength(1)
-      // Remove 'details' attributes for comparison
-      delete totals.prev30Days?.NewFormsCreated.details
-      delete totals.prev30Days?.Submissions.details
       expect(totals.prev30Days).toEqual({
         NewFormsCreated: {
           count: 4
@@ -538,11 +532,6 @@ describe('runMetricsCollectionJob', () => {
           count: 1
         }
       })
-      expect(totals.lastYear?.NewFormsCreated.details).toHaveLength(7)
-      expect(totals.lastYear?.Submissions.details).toHaveLength(2)
-      // Remove 'details' attributes for comparison
-      delete totals.lastYear?.NewFormsCreated.details
-      delete totals.lastYear?.Submissions.details
       expect(totals.lastYear).toEqual({
         NewFormsCreated: {
           count: 19
@@ -551,13 +540,6 @@ describe('runMetricsCollectionJob', () => {
           count: 7
         }
       })
-      expect(totals.prevYear?.NewFormsCreated.details).toHaveLength(1)
-      expect(totals.prevYear?.FormsFirstPublished.details).toHaveLength(1)
-      expect(totals.prevYear?.FormsRePublished.details).toHaveLength(1)
-      // Remove 'details' attributes for comparison
-      delete totals.prevYear?.NewFormsCreated.details
-      delete totals.prevYear?.FormsFirstPublished.details
-      delete totals.prevYear?.FormsRePublished.details
       expect(totals.prevYear).toEqual({
         FormsFirstPublished: {
           count: 1
@@ -1192,9 +1174,41 @@ describe('runMetricsCollectionJob', () => {
       })
     })
   })
+  describe('generateDrilldownReport', () => {
+    it('should generate drilldown report', async () => {
+      const mockNewSession = /** @type {any} */ ({
+        endSession: jest.fn().mockResolvedValue(undefined)
+      })
+      jest.mocked(client.startSession).mockReturnValue(mockNewSession)
+
+      const drilldownMetrics = /** @type {WithId<FormDrilldownMetric>[]} */ ([
+        {
+          type: FormMetricType.DrilldownMetric,
+          formId: 'form-id-1',
+          createdAt: new Date('2026-02-02')
+        }
+      ])
+      // @ts-expect-error - partial mock of data
+      jest.mocked(getDrilldownRecords).mockReturnValueOnce(drilldownMetrics)
+
+      const res = await generateDrilldownReport(
+        'last7Days',
+        FormMetricName.NewFormsCreated
+      )
+      expect(res).toEqual({
+        drilldownRows: [
+          {
+            createdAt: new Date('2026-02-02'),
+            formId: 'form-id-1',
+            type: FormMetricType.DrilldownMetric
+          }
+        ]
+      })
+    })
+  })
 })
 
 /**
  * @import { WithId } from 'mongodb'
- * @import { AuditRecordInput, FormOverviewMetric, FormTimelineMetric } from '@defra/forms-model'
+ * @import { AuditRecordInput, FormDrilldownMetric, FormOverviewMetric, FormTimelineMetric } from '@defra/forms-model'
  */


### PR DESCRIPTION
Prevents potentially blowing Mongo doc size limits by saving drill down detail records as separate documents from the 'totals' record.