### PR TITLE
Fix: Metrics Generation to Include Day Before

### DIFF
--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -137,7 +137,7 @@ export async function collectMetrics(
   return {
     success: true,
     message: 'Completed ok',
-    processMoreBatches: formatDateOnly(reportDate) < formatDateOnly(yesterday),
+    processMoreBatches: formatDateOnly(reportDate) <= formatDateOnly(yesterday),
     endDate: reportEndDate
   }
 }


### PR DESCRIPTION
Ensuring metrics are generated up to and including yesterday.