### PR TITLE
fix/df-1260: Fixed incorrect window calc range

### DIFF
--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -22,7 +22,7 @@ services:
 
   oidc:
     image: ghcr.io/soluto/oidc-server-mock:0.6.0
-    container_name: oidc-mock-test
+    container_name: oidc-mock-test-audit
     ports:
       - '5556:80'
     environment:
@@ -69,13 +69,38 @@ services:
     ports:
       - '3003:3003'
     environment:
-      MONGO_URI: mongodb://mongo_test:27017/forms-audit-api-test?replicaSet=rs0&directConnection=true
+      HOST: 0.0.0.0
       PORT: 3003
       NODE_ENV: production
+      SERVICE_VERSION: integration-test
+      ENVIRONMENT: local
+      LOG_ENABLED: true
+      LOG_LEVEL: info
+      LOG_FORMAT: ecs
+      MONGO_URI: mongodb://mongo_test:27017/forms-audit-api-test?replicaSet=rs0&directConnection=true
+      MONGO_DATABASE: forms-audit-api
+      HTTP_PROXY: ''
+      CDP_HTTPS_PROXY: ''
+      ENABLE_SECURE_CONTEXT: false
+      ENABLE_METRICS: false
+      CACHE_ENABLED: false
       OIDC_JWKS_URI: 'http://oidc:80/.well-known/openid-configuration/jwks'
       OIDC_VERIFY_AUD: 'newman-test-client'
       OIDC_VERIFY_ISS: 'http://oidc:80'
-      ROLE_EDITOR_GROUP_ID: '7049296f-2156-4d61-8ac3-349276438ef9'
+      ENTITLEMENT_URL: http://forms-entitlement-api-test:3004
+      MANAGER_URL: http://forms-manager-api-test:3001
+      SUBMISSION_URL: http://forms-submission-api-test:3002
+      TRACING_HEADER: x-trace-id
+      AWS_REGION: eu-west-2
+      SQS_ENDPOINT: http://localhost:4566
+      EVENTS_SQS_QUEUE_URL: http://sqs.eu-west-2.127.0.0.1:4566/000000000000/forms_audit_events
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      RECEIVE_MESSAGE_TIMEOUT_MS: 5000
+      SQS_MAX_NUMBER_OF_MESSAGES: 10
+      SQS_VISIBILITY_TIMEOUT: 1
+      EVENTS_SQS_DLQ_ARN: arn:aws:sqs:eu-west-2:000000000000:forms_audit_events-deadletter
+      METRICS_CRONTAB: 0 3 * * *
     depends_on:
       mongo_test:
         condition: service_healthy

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -6,6 +6,7 @@ import {
 import {
   add,
   differenceInDays,
+  endOfDay,
   min,
   startOfDay,
   sub,
@@ -561,7 +562,8 @@ function handleTimeslot(
   endOfSlot,
   saveDrilldown
 ) {
-  if (dateFallsInsideTimeslot(createdAt, startOfSlot, endOfSlot)) {
+  const endOfDaySlot = endOfDay(endOfSlot)
+  if (dateFallsInsideTimeslot(createdAt, startOfSlot, endOfDaySlot)) {
     handleMetricValue(metric, period, metricCalcType, saveDrilldown)
   }
 }

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -375,10 +375,18 @@ describe('runMetricsCollectionJob', () => {
         {
           type: FormMetricType.TimelineMetric,
           formId: 'form-id',
-          formStatus: FormStatus.Draft,
+          formStatus: FormStatus.Live,
+          metricName: FormMetricName.Submissions,
+          metricValue: 5,
+          createdAt: new Date('2025-12-10T10:00:00.000Z')
+        },
+        {
+          type: FormMetricType.TimelineMetric,
+          formId: 'form-id',
+          formStatus: FormStatus.Live,
           metricName: FormMetricName.Submissions,
           metricValue: 1,
-          createdAt: new Date('2025-12-28')
+          createdAt: new Date('2026-01-01T10:00:00.000Z')
         },
         {
           type: FormMetricType.TimelineMetric,
@@ -386,7 +394,23 @@ describe('runMetricsCollectionJob', () => {
           formStatus: FormStatus.Live,
           metricName: FormMetricName.Submissions,
           metricValue: 6,
-          createdAt: new Date('2025-12-29')
+          createdAt: new Date('2025-12-29T10:00:00.000Z')
+        },
+        {
+          type: FormMetricType.TimelineMetric,
+          formId: 'form-id',
+          formStatus: FormStatus.Live,
+          metricName: FormMetricName.Submissions,
+          metricValue: 4,
+          createdAt: new Date('2025-12-30T10:00:00.000Z')
+        },
+        {
+          type: FormMetricType.TimelineMetric,
+          formId: 'form-id',
+          formStatus: FormStatus.Live,
+          metricName: FormMetricName.Submissions,
+          metricValue: 3,
+          createdAt: new Date('2025-12-31T10:00:00.000Z')
         },
         {
           type: FormMetricType.TimelineMetric,
@@ -394,7 +418,7 @@ describe('runMetricsCollectionJob', () => {
           formStatus: FormStatus.Live,
           metricName: FormMetricName.Submissions,
           metricValue: 1,
-          createdAt: new Date('2025-11-20')
+          createdAt: new Date('2025-11-20T10:00:00.000Z')
         },
         {
           type: FormMetricType.TimelineMetric,
@@ -402,7 +426,7 @@ describe('runMetricsCollectionJob', () => {
           formStatus: FormStatus.Draft,
           metricName: FormMetricName.Submissions,
           metricValue: 2,
-          createdAt: new Date('2025-11-02')
+          createdAt: new Date('2025-11-02T10:00:00.000Z')
         },
         // Within last 7 days
         createTimelineMetric(
@@ -494,7 +518,7 @@ describe('runMetricsCollectionJob', () => {
       const totals = await recalcMetrics(new Date('2026-01-01'), mockSession)
 
       expect(totals.last7Days?.NewFormsCreated.details).toHaveLength(3)
-      expect(totals.last7Days?.Submissions.details).toHaveLength(1)
+      expect(totals.last7Days?.Submissions.details).toHaveLength(4)
       // Remove 'details' attributes for comparison
       delete totals.last7Days?.NewFormsCreated.details
       delete totals.last7Days?.Submissions.details
@@ -503,7 +527,7 @@ describe('runMetricsCollectionJob', () => {
           count: 6
         },
         Submissions: {
-          count: 6
+          count: 14
         }
       })
       expect(totals.prev7Days).toEqual({
@@ -512,7 +536,7 @@ describe('runMetricsCollectionJob', () => {
         }
       })
       expect(totals.last30Days?.NewFormsCreated.details).toHaveLength(5)
-      expect(totals.last30Days?.Submissions.details).toHaveLength(1)
+      expect(totals.last30Days?.Submissions.details).toHaveLength(5)
       // Remove 'details' attributes for comparison
       delete totals.last30Days?.NewFormsCreated.details
       delete totals.last30Days?.Submissions.details
@@ -521,7 +545,7 @@ describe('runMetricsCollectionJob', () => {
           count: 15
         },
         Submissions: {
-          count: 6
+          count: 19
         }
       })
       expect(totals.prev30Days).toEqual({
@@ -537,7 +561,7 @@ describe('runMetricsCollectionJob', () => {
           count: 19
         },
         Submissions: {
-          count: 7
+          count: 20
         }
       })
       expect(totals.prevYear).toEqual({
@@ -557,7 +581,7 @@ describe('runMetricsCollectionJob', () => {
       expect(totals.allTime?.NewFormsCreated.details).toHaveLength(8)
       expect(totals.allTime?.FormsFirstPublished.details).toHaveLength(1)
       expect(totals.allTime?.FormsRePublished.details).toHaveLength(1)
-      expect(totals.allTime?.Submissions.details).toHaveLength(2)
+      expect(totals.allTime?.Submissions.details).toHaveLength(6)
       // Remove 'details' attributes for comparison
       delete totals.allTime?.NewFormsCreated.details
       delete totals.allTime?.FormsFirstPublished.details
@@ -565,7 +589,7 @@ describe('runMetricsCollectionJob', () => {
       delete totals.allTime?.Submissions.details
       expect(totals.allTime).toEqual({
         Submissions: {
-          count: 7
+          count: 20
         },
         FormsFirstPublished: {
           count: 1
@@ -581,10 +605,10 @@ describe('runMetricsCollectionJob', () => {
         }
       })
       expect(totals.draftSubmissions).toEqual({
-        'form-id': 3
+        'form-id': 2
       })
       expect(totals.liveSubmissions).toEqual({
-        'form-id': 7
+        'form-id': 20
       })
       expect(totals.republished).toEqual({
         'form-id-1': 1


### PR DESCRIPTION
Some incorrect 7 days / 30 days / All time metrics values were noticed, specifically for form 'SFI 26, Window 2 EOI'.
This was a newly-published form, and had only been live for about 3 days, so it could easily be seen that the figures were incorrect.
The 'All time' total was fine, but '7 days' and '30 days' did not give the correct figures.
The bug was due to the handling of the time period windows where the end date (of the window) did not include a time element, so the last day of a window was always being omitted from the calcs.