### PR TITLE
Feat/df 1257: Handle welsh metrics as separate metrics

### DIFF
--- a/docs/metrics-reporting.md
+++ b/docs/metrics-reporting.md
@@ -1,0 +1,221 @@
+# Metrics Reporting (`/report`)
+
+This document explains how the forms-audit-api collects, stores and serves form metrics, and how the `/report` family of endpoints turns raw data into the dashboard tiles and drilldowns.
+
+## Overview
+
+Metrics answer questions like "how many forms were created in the last 7 days?", "how long does it take to publish a form?" and "how many submissions has form X had?". The system is split into two concerns:
+
+1. **Collection** – a scheduled job (`metrics-job.js` / `cron.js`) pulls data from `forms-manager`, `forms-submission` and this service's own audit event collection, then aggregates it into rolling time-window totals.
+2. **Reporting** – the `/report*` routes read the pre-aggregated data back out, with no heavy computation at request time (`generateReport`, `generateReportForForm`, `generateDrilldownReport`).
+
+All metric documents live in a single Mongo collection (see [`METRICS_COLLECTION_NAME`](../src/mongo.js)), distinguished by a `type` discriminator field.
+
+## Data structures
+
+All types are stored as plain documents in the metrics collection, and are typed via `@defra/forms-model` (`FormMetricName`, `FormMetricType`, `FormStatus`). The `type` field determines which "shape" a document has:
+
+| `type` (`FormMetricType`)                                | Purpose                                                                                                                           | Written by                                   | Read by                                                                    |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------- |
+| `OverviewMetric`                                         | One snapshot document per form/status (draft or live) describing the form's current state (name, org, features, submission count) | `saveFormOverviewMetrics`                    | `getAllOverviewMetrics` → `generateReport`                                 |
+| `TimelineMetric`                                         | An immutable event record: "this happened, at this time, for this form" (e.g. a submission, a publish, a form created)            | `saveFormTimelineMetrics`                    | `getAllTimelineMetrics` / `getFormTimelineMetricsCursor` → `recalcMetrics` |
+| `TotalsMetric`                                           | A single, latest, pre-computed rollup document covering all the time windows (last 7 days, last 30 days, etc.)                    | `updateMetricTotals`                         | `getMetricTotals` → `generateReport` / `generateReportForForm`             |
+| `DrilldownMetric`                                        | The individual `TimelineMetric` records that make up a tile's count, saved separately so the totals document stays small          | `saveDrilldownRecords` (via `saveDrilldown`) | `getDrilldownRecords` → `generateDrilldownReport`                          |
+| `form-metric-control` (constant, not a `FormMetricType`) | Singleton lock/checkpoint record used to serialize the job across multiple containers and remember where collection left off      | `grabLock` / `releaseLock`                   | `runMetricsCollectionBatch`                                                |
+
+### `FormOverviewMetric`
+
+One per `(formId, formStatus)` pair, replaced wholesale on every collection run:
+
+```js
+{
+  type: 'OverviewMetric',
+  formId: 'abc123',
+  formStatus: 'live' | 'draft',
+  summaryMetrics: { name, organisation, teamName, /* + daysToPublish, republished added at read time */ },
+  featureMetrics: { /* e.g. welsh translation, email confirmation flags */ }
+}
+```
+
+### `FormTimelineMetric`
+
+One per discrete event. `metricName` is one of the `FormMetricName` values, each with a fixed **calculation type** defined in [`metricConfig`](../src/service/metrics-helper.js):
+
+| `FormMetricName`      | Calculation type          | Meaning                                                                                                                |
+| --------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `NewFormsCreated`     | AccumulationWithDrilldown | Count of forms created in the window, drilldown available                                                              |
+| `FormsFirstPublished` | AccumulationWithDrilldown | Count of first-time publishes                                                                                          |
+| `FormsRePublished`    | AccumulationWithDrilldown | Count of subsequent republishes                                                                                        |
+| `Submissions`         | AccumulationWithDrilldown | Count of form submissions (live only counts toward windowed totals; draft submissions are tracked separately per-form) |
+| `FormsInDraft`        | Snapshot                  | Point-in-time count of forms currently in draft with no live version                                                   |
+| `TimeToPublish`       | Average                   | Days between first draft and first publish, averaged across forms in the window                                        |
+
+```js
+{
+  type: 'TimelineMetric',
+  formId: 'abc123',
+  formStatus: 'live' | 'draft',
+  metricName: 'submissions' | 'formsFirstPublished' | ...,
+  metricValue: 1,       // or a day-count for TimeToPublish, or a running count for FormsInDraft
+  createdAt: Date
+}
+```
+
+### `FormTotalsMetric`
+
+The single rollup document. Each time-window key holds a map of `metricName → { count }` (or `{ count, details }` for drilldown-enabled metrics before they're stripped out and persisted separately):
+
+```js
+{
+  type: 'TotalsMetric',
+  last7Days:  { newFormsCreated: { count }, submissions: { count }, formsInDraft: { count }, timeToPublish: { count }, ... },
+  prev7Days:  { ... },
+  last30Days: { ... },
+  prev30Days: { ... },
+  lastYear:   { ... },
+  prevYear:   { ... },
+  allTime:    { ... },
+  liveSubmissions:  { formId: totalCount },   // per-form maps, not time-windowed
+  draftSubmissions: { formId: totalCount },
+  daysToPublish:    { formId: days },
+  republished:      { formId: count },
+  earliestDate: Date,   // earliest submission ever seen (fallback if none)
+  updatedAt: Date
+}
+```
+
+### `FormDrilldownMetric`
+
+The raw contributing records behind an `AccumulationWithDrilldown` tile, saved with enough context to look them back up:
+
+```js
+{
+  type: 'DrilldownMetric',
+  periodName: 'last7Days' | 'last30Days' | 'allTime',
+  metricName: 'submissions' | ...,
+  formId, metricValue, createdAt
+}
+```
+
+Only `last7Days`, `last30Days` and `allTime` are exposed for drilldown (see `metricDrilldownPeriods`); the other windows (`prev7Days`, `prev30Days`, `lastYear`, `prevYear`) are used for trend comparisons only.
+
+### Control record (`form-metric-control`)
+
+A singleton document that prevents two containers running the job concurrently and records where the last successful run got to:
+
+```js
+{
+  type: 'form-metric-control',
+  locked: boolean,
+  jobStart: Date,
+  jobEnd: Date | null,
+  lastSuccessfulRunDate: Date | null,
+  lastRunResult: string,
+  updatedAt: Date
+}
+```
+
+## Gathering process (collection)
+
+Collection is triggered by a cron schedule (`config.metricsCrontab`, registered in [`cron.js`](../src/plugins/cron.js)) or manually via `POST /report/regenerate`. Both call `runMetricsCollectionJob` in [`metrics-job.js`](../src/service/metrics-job.js).
+
+```mermaid
+flowchart TD
+    A[Cron trigger / POST /report/regenerate] --> B[runMetricsCollectionJob]
+    B --> C[runMetricsCollectionBatch]
+    C --> D{grabLock}
+    D -- already locked --> Z[Abort - another container running]
+    D -- lock acquired --> E[collectMetrics]
+    E --> F[collectManagerOverviewMetrics]
+    F --> G[collectTimelineMetrics from forms-submission]
+    G --> H[collectTimelineMetricsFromAudit]
+    H --> I[recalcMetrics -> FormTotalsMetric]
+    I --> J[updateMetricTotals + saveDrilldown]
+    J --> K[releaseLock, record lastSuccessfulRunDate]
+    K --> L{processMoreBatches?}
+    L -- yes --> C
+    L -- no --> M[Done]
+```
+
+1. **Locking** – `grabLock` atomically flips the control record to `locked: true` so only one container processes a batch at a time; if already locked, the job silently exits.
+2. **Batching** – `collectMetrics` figures out the date range to process: from `lastSuccessfulRunDate + 1 day` up to yesterday, capped at `MAX_DAYS_PER_BATCH` (30) days per batch. This lets a first-ever run backfill history (from a fixed `EARLIEST_REPORT_DATE_AS_STRING` of `2025-07-01`) in manageable chunks, running `runMetricsCollectionBatch` repeatedly (`processMoreBatches`) until caught up.
+3. **Overview metrics** (`collectManagerOverviewMetrics`) – calls `forms-manager`'s `/report/overview` endpoint page by page (20 forms/page, to keep each call fast), deletes all existing `OverviewMetric` documents, and re-saves fresh draft/live snapshots per form.
+4. **Timeline metrics from submissions** (`collectTimelineMetrics`) – for each day in the batch, calls `forms-submission`'s `/report/timeline?date=...` endpoint and stores each returned entry as a `TimelineMetric`.
+5. **Timeline metrics from audit events** (`collectTimelineMetricsFromAudit`) – derives additional timeline metrics directly from this service's own audit trail for the same day:
+
+- `FORM_CREATED` audit events → `NewFormsCreated` metric, and increments a running "forms currently in draft" counter.
+- `FORM_LIVE_CREATED_FROM_DRAFT` audit events → either `FormsFirstPublished` (+ `TimeToPublish`, calculated from the form's first `NewFormsCreated` record) on first publish, or `FormsRePublished` on subsequent publishes; first publishes decrement the "forms in draft" counter.
+- The resulting draft count is stored as a `FormsInDraft` snapshot metric for that day.
+
+6. **Recalculation** (`recalcMetrics`) – once all days in the batch are stored as `TimelineMetric` documents, this walks every timeline metric (via a Mongo cursor) and buckets it into fixed windows relative to the report date: `last7Days`, `prev7Days`, `last30Days`, `prev30Days`, `lastYear`, `prevYear`, `allTime`. For each window, `handleMetricValue` applies the metric's calculation type:
+
+- **Accumulation / AccumulationWithDrilldown** – running sum (`updateMetricTotal`); drilldown-enabled metrics also keep a `details` array of the minimal contributing records.
+- **Snapshot** – last value wins (`setMetricTotal`), used for `FormsInDraft`.
+- **Average** – running total + count (`updateMetricAverage`), divided down to an average by `calcAverages` at the end.
+
+It also builds per-form maps outside the time windows: total live/draft submissions per form, days-to-publish per form, and republish counts per form — these back the per-row columns in the overview table rather than the summary tiles. 7. **Persistence** (`updateMetricTotals`) – replaces the single `TotalsMetric` document and all `DrilldownMetric` documents transactionally: existing totals/drilldown records are deleted, `saveDrilldown` extracts and stores each tile's `details` array as separate `DrilldownMetric` documents (to keep the totals document small), then the stripped-down totals are saved. 8. **Unlocking** (`releaseLock`) – always runs (`finally`), records success/failure message and, on success, advances `lastSuccessfulRunDate` to the batch's end date so the next run resumes from there.
+
+All of collection runs inside a single Mongo `ClientSession`/transaction per batch (`session.withTransaction`), so a failed batch leaves previously-committed data untouched.
+
+## Reporting process (`/report` routes)
+
+Defined in [`routes/report.js`](../src/routes/report.js). These routes only read pre-computed data — no aggregation happens on request.
+
+```mermaid
+flowchart LR
+    subgraph Routes
+      R1[GET /report]
+      R2["GET /report/:formId"]
+      R3["GET /report/:period/:metricName"]
+      R4[POST /report/regenerate]
+    end
+    R1 --> S1[generateReport]
+    R2 --> S2[generateReportForForm]
+    R3 --> S3[generateDrilldownReport]
+    R4 --> S4[clearMetricsDatabase + runMetricsCollectionJob]
+
+    S1 --> D1[(OverviewMetric docs)]
+    S1 --> D2[(TotalsMetric doc)]
+    S2 --> D3[recalcMetrics over form's TimelineMetric docs]
+    S3 --> D4[(DrilldownMetric docs)]
+```
+
+### `GET /report`
+
+Handled by `generateReport(filter)`:
+
+- Fetches all `OverviewMetric` documents via `getAllOverviewMetrics`, optionally filtered by `searchText` (form name, case-insensitive regex), `status` (draft/live), `org` and `features` (all via query params validated by Joi).
+- Fetches the single `TotalsMetric` document via `getMetricTotals`.
+- Calls `applyExtraColumns` to merge in `submissionsCount`, `daysToPublish` and `republished` (looked up per-form from the totals' per-form maps) into each overview row.
+- Returns `{ overview: [...], totals: {...} }` — `overview` drives the per-form table, `totals` drives the summary tiles.
+
+### `GET /report/{formId}`
+
+Handled by `generateReportForForm(formId)`:
+
+- Instead of reading pre-aggregated totals, it re-runs `recalcMetrics` scoped to just that form's `TimelineMetric` documents (via `getFormTimelineMetricsCursor`), as of "yesterday", giving per-form windowed totals on demand.
+- Adds `earliestDate`/`updatedAt` from the global `TotalsMetric` document so the UI can show the overall reporting date range.
+- Returns `{ totals: {...} }`.
+
+### `GET /report/{period}/{metricName}`
+
+Handled by `generateDrilldownReport(period, metricName)`:
+
+- `period` must be one of `last7Days`, `last30Days`, `allTime` (the only periods drilldown was retained for); `metricName` must be a valid `FormMetricName`.
+- Reads matching `DrilldownMetric` documents via `getDrilldownRecords` and returns `{ drilldownRows: [...] }` — the list of individual events that make up a summary tile, for the "click a tile to see details" UI.
+
+### `POST /report/regenerate`
+
+Admin-only (requires the `DeadLetterQueues` scope). Wipes all metrics data (`clearMetricsDatabase`, everything except the control record) and kicks off `runMetricsCollectionJob` **without awaiting it** ("fire-and-forget") so the HTTP request doesn't time out while the (potentially multi-batch, historical) job runs in the background.
+
+## Key files
+
+| File                                                                                            | Responsibility                               |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| [`src/routes/report.js`](../src/routes/report.js)                                               | HTTP routes, request validation              |
+| [`src/service/metrics.js`](../src/service/metrics.js)                                           | Core collection + reporting logic            |
+| [`src/service/metrics-helper.js`](../src/service/metrics-helper.js)                             | Metric calculation-type config, date helpers |
+| [`src/service/metrics-job.js`](../src/service/metrics-job.js)                                   | Job orchestration, locking, batching loop    |
+| [`src/plugins/cron.js`](../src/plugins/cron.js)                                                 | Schedules the job via `node-cron`            |
+| [`src/repositories/metrics-repository.js`](../src/repositories/metrics-repository.js)           | All Mongo reads/writes for metric documents  |
+| [`src/repositories/audit-record-repository.js`](../src/repositories/audit-record-repository.js) | Supplies audit-derived timeline metrics      |

--- a/docs/metrics-reporting.md
+++ b/docs/metrics-reporting.md
@@ -11,17 +11,19 @@ Metrics answer questions like "how many forms were created in the last 7 days?",
 
 All metric documents live in a single Mongo collection (see [`METRICS_COLLECTION_NAME`](../src/mongo.js)), distinguished by a `type` discriminator field.
 
+Every collection pass also runs a second, **Welsh-only** pass alongside the "all languages" pass (see [`CY`](../src/constants.js)), so timeline, totals and drilldown records exist in two variants: one with no `language` field (all submissions/forms) and one with `language: 'cy'` (Welsh submissions/forms only). Reporting endpoints accept an optional `language` parameter to pick which variant to read back.
+
 ## Data structures
 
 All types are stored as plain documents in the metrics collection, and are typed via `@defra/forms-model` (`FormMetricName`, `FormMetricType`, `FormStatus`). The `type` field determines which "shape" a document has:
 
-| `type` (`FormMetricType`)                                | Purpose                                                                                                                           | Written by                                   | Read by                                                                    |
-| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------- |
-| `OverviewMetric`                                         | One snapshot document per form/status (draft or live) describing the form's current state (name, org, features, submission count) | `saveFormOverviewMetrics`                    | `getAllOverviewMetrics` → `generateReport`                                 |
-| `TimelineMetric`                                         | An immutable event record: "this happened, at this time, for this form" (e.g. a submission, a publish, a form created)            | `saveFormTimelineMetrics`                    | `getAllTimelineMetrics` / `getFormTimelineMetricsCursor` → `recalcMetrics` |
-| `TotalsMetric`                                           | A single, latest, pre-computed rollup document covering all the time windows (last 7 days, last 30 days, etc.)                    | `updateMetricTotals`                         | `getMetricTotals` → `generateReport` / `generateReportForForm`             |
-| `DrilldownMetric`                                        | The individual `TimelineMetric` records that make up a tile's count, saved separately so the totals document stays small          | `saveDrilldownRecords` (via `saveDrilldown`) | `getDrilldownRecords` → `generateDrilldownReport`                          |
-| `form-metric-control` (constant, not a `FormMetricType`) | Singleton lock/checkpoint record used to serialize the job across multiple containers and remember where collection left off      | `grabLock` / `releaseLock`                   | `runMetricsCollectionBatch`                                                |
+| `type` (`FormMetricType`)                                | Purpose                                                                                                                                                | Written by                                   | Read by                                                                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- | -------------------------------------------------------------------------- |
+| `OverviewMetric`                                         | One snapshot document per form/status (draft or live) describing the form's current state (name, org, language, submission count)                      | `saveFormOverviewMetrics`                    | `getAllOverviewMetrics` → `generateReport`                                 |
+| `TimelineMetric`                                         | An immutable event record: "this happened, at this time, for this form" (e.g. a submission, a publish, a form created)                                 | `saveFormTimelineMetrics`                    | `getAllTimelineMetrics` / `getFormTimelineMetricsCursor` → `recalcMetrics` |
+| `TotalsMetric`                                           | A pre-computed rollup document covering all the time windows (last 7 days, last 30 days, etc.) - one per language variant (all languages + Welsh-only) | `updateMetricTotals`                         | `getMetricTotals` → `generateReport` / `generateReportForForm`             |
+| `DrilldownMetric`                                        | The individual `TimelineMetric` records that make up a tile's count, saved separately so the totals document stays small                               | `saveDrilldownRecords` (via `saveDrilldown`) | `getDrilldownRecords` → `generateDrilldownReport`                          |
+| `form-metric-control` (constant, not a `FormMetricType`) | Singleton lock/checkpoint record used to serialize the job across multiple containers and remember where collection left off                           | `grabLock` / `releaseLock`                   | `runMetricsCollectionBatch`                                                |
 
 ### `FormOverviewMetric`
 
@@ -32,6 +34,7 @@ One per `(formId, formStatus)` pair, replaced wholesale on every collection run:
   type: 'OverviewMetric',
   formId: 'abc123',
   formStatus: 'live' | 'draft',
+  language: 'cy',       // present only if the form supports/was submitted in Welsh; drives language filtering
   summaryMetrics: { name, organisation, teamName, /* + daysToPublish, republished added at read time */ },
   featureMetrics: { /* e.g. welsh translation, email confirmation flags */ }
 }
@@ -57,17 +60,19 @@ One per discrete event. `metricName` is one of the `FormMetricName` values, each
   formStatus: 'live' | 'draft',
   metricName: 'submissions' | 'formsFirstPublished' | ...,
   metricValue: 1,       // or a day-count for TimeToPublish, or a running count for FormsInDraft
-  createdAt: Date
+  createdAt: Date,
+  language: 'cy'         // only present on records collected during the Welsh-only pass
 }
 ```
 
 ### `FormTotalsMetric`
 
-The single rollup document. Each time-window key holds a map of `metricName → { count }` (or `{ count, details }` for drilldown-enabled metrics before they're stripped out and persisted separately):
+The rollup document - one is stored per language variant (no `language` field for the all-languages totals, `language: 'cy'` for the Welsh-only totals). Each time-window key holds a map of `metricName → { count }` (or `{ count, details }` for drilldown-enabled metrics before they're stripped out and persisted separately):
 
 ```js
 {
   type: 'TotalsMetric',
+  language: 'cy',       // omitted for the all-languages totals document
   last7Days:  { newFormsCreated: { count }, submissions: { count }, formsInDraft: { count }, timeToPublish: { count }, ... },
   prev7Days:  { ... },
   last30Days: { ... },
@@ -75,7 +80,8 @@ The single rollup document. Each time-window key holds a map of `metricName → 
   lastYear:   { ... },
   prevYear:   { ... },
   allTime:    { ... },
-  liveSubmissions:  { formId: totalCount },   // per-form maps, not time-windowed
+  // per-form maps, not time-windowed
+  liveSubmissions:  { formId: totalCount },
   draftSubmissions: { formId: totalCount },
   daysToPublish:    { formId: days },
   republished:      { formId: count },
@@ -93,7 +99,8 @@ The raw contributing records behind an `AccumulationWithDrilldown` tile, saved w
   type: 'DrilldownMetric',
   periodName: 'last7Days' | 'last30Days' | 'allTime',
   metricName: 'submissions' | ...,
-  formId, metricValue, createdAt
+  formId, metricValue, createdAt,
+  language: 'cy'   // carried over from the parent totals document, if present
 }
 ```
 
@@ -126,10 +133,10 @@ flowchart TD
     C --> D{grabLock}
     D -- already locked --> Z[Abort - another container running]
     D -- lock acquired --> E[collectMetrics]
-    E --> F[collectManagerOverviewMetrics]
-    F --> G[collectTimelineMetrics from forms-submission]
-    G --> H[collectTimelineMetricsFromAudit]
-    H --> I[recalcMetrics -> FormTotalsMetric]
+    E --> F["collectManagerOverviewMetrics (returns language-capable form ids)"]
+    F --> G["collectTimelineMetrics from forms-submission (all languages + Welsh-only)"]
+    G --> H["collectTimelineMetricsFromAudit (all languages + Welsh-only)"]
+    H --> I["recalcMetrics x2 -> FormTotalsMetric per language"]
     I --> J[updateMetricTotals + saveDrilldown]
     J --> K[releaseLock, record lastSuccessfulRunDate]
     K --> L{processMoreBatches?}
@@ -139,21 +146,21 @@ flowchart TD
 
 1. **Locking** – `grabLock` atomically flips the control record to `locked: true` so only one container processes a batch at a time; if already locked, the job silently exits.
 2. **Batching** – `collectMetrics` figures out the date range to process: from `lastSuccessfulRunDate + 1 day` up to yesterday, capped at `MAX_DAYS_PER_BATCH` (30) days per batch. This lets a first-ever run backfill history (from a fixed `EARLIEST_REPORT_DATE_AS_STRING` of `2025-07-01`) in manageable chunks, running `runMetricsCollectionBatch` repeatedly (`processMoreBatches`) until caught up.
-3. **Overview metrics** (`collectManagerOverviewMetrics`) – calls `forms-manager`'s `/report/overview` endpoint page by page (20 forms/page, to keep each call fast), deletes all existing `OverviewMetric` documents, and re-saves fresh draft/live snapshots per form.
-4. **Timeline metrics from submissions** (`collectTimelineMetrics`) – for each day in the batch, calls `forms-submission`'s `/report/timeline?date=...` endpoint and stores each returned entry as a `TimelineMetric`.
-5. **Timeline metrics from audit events** (`collectTimelineMetricsFromAudit`) – derives additional timeline metrics directly from this service's own audit trail for the same day:
+3. **Overview metrics** (`collectManagerOverviewMetrics`) – calls `forms-manager`'s `/report/overview` endpoint page by page (20 forms/page, to keep each call fast), deletes all existing `OverviewMetric` documents, and re-saves fresh draft/live snapshots per form. While paging through, it also builds and returns `languageCapableForms` – `{ draftIds, liveIds }` sets of form IDs whose draft/live `summaryMetrics` show a `language` (e.g. Welsh) – used to scope the Welsh-only audit pass below.
+4. **Timeline metrics from submissions** (`collectTimelineMetrics`) – for each day in the batch, calls `forms-submission`'s `/report/timeline?date=...` endpoint and stores each returned entry as a `TimelineMetric`. This runs **twice per day**: once with no `language` param (all languages) and once with `language=cy` (Welsh-only); Welsh-only records are tagged with `language: 'cy'` before being saved.
+5. **Timeline metrics from audit events** (`collectTimelineMetricsFromAudit`) – derives additional timeline metrics directly from this service's own audit trail for the same day, also run twice per day (all languages, then Welsh-only using `languageFormIds` to restrict the audit query to language-capable forms):
 
-- `FORM_CREATED` audit events → `NewFormsCreated` metric, and increments a running "forms currently in draft" counter.
-- `FORM_LIVE_CREATED_FROM_DRAFT` audit events → either `FormsFirstPublished` (+ `TimeToPublish`, calculated from the form's first `NewFormsCreated` record) on first publish, or `FormsRePublished` on subsequent publishes; first publishes decrement the "forms in draft" counter.
-- The resulting draft count is stored as a `FormsInDraft` snapshot metric for that day.
+- `FORM_CREATED` audit events → `NewFormsCreated` metric, and increments a running "forms currently in draft" counter (seeded from yesterday's `FormsInDraft` value for that language via `getNumberOfFormsInDraft`).
+- `FORM_LIVE_CREATED_FROM_DRAFT` audit events → either `FormsFirstPublished` (+ `TimeToPublish`, calculated from the form's first `NewFormsCreated` record) on first publish, or `FormsRePublished` on subsequent publishes; first publishes decrement the "forms in draft" counter. On the Welsh-only pass, first-publish/first-draft lookups are skipped unless the form is in `languageFormIds`.
+- The resulting draft count is stored as a `FormsInDraft` snapshot metric for that day, tagged with `language` where applicable.
 
-6. **Recalculation** (`recalcMetrics`) – once all days in the batch are stored as `TimelineMetric` documents, this walks every timeline metric (via a Mongo cursor) and buckets it into fixed windows relative to the report date: `last7Days`, `prev7Days`, `last30Days`, `prev30Days`, `lastYear`, `prevYear`, `allTime`. For each window, `handleMetricValue` applies the metric's calculation type:
+6. **Recalculation** (`recalcMetrics`) – run once per language (all languages, then Welsh-only) once all days in the batch are stored as `TimelineMetric` documents. It walks every timeline metric matching that language (via a Mongo cursor) and buckets it into fixed windows relative to the report date: `last7Days`, `prev7Days`, `last30Days`, `prev30Days`, `lastYear`, `prevYear`, `allTime`. For each window, `handleMetricValue` applies the metric's calculation type:
 
 - **Accumulation / AccumulationWithDrilldown** – running sum (`updateMetricTotal`); drilldown-enabled metrics also keep a `details` array of the minimal contributing records.
-- **Snapshot** – last value wins (`setMetricTotal`), used for `FormsInDraft`.
+- **Snapshot** – last value wins (`setMetricTotal`), used for `FormsInDraft`. Since the cursor can return `FormsInDraft` records for other languages too, non-matching-language records are skipped explicitly before applying the calc type.
 - **Average** – running total + count (`updateMetricAverage`), divided down to an average by `calcAverages` at the end.
 
-It also builds per-form maps outside the time windows: total live/draft submissions per form, days-to-publish per form, and republish counts per form — these back the per-row columns in the overview table rather than the summary tiles. 7. **Persistence** (`updateMetricTotals`) – replaces the single `TotalsMetric` document and all `DrilldownMetric` documents transactionally: existing totals/drilldown records are deleted, `saveDrilldown` extracts and stores each tile's `details` array as separate `DrilldownMetric` documents (to keep the totals document small), then the stripped-down totals are saved. 8. **Unlocking** (`releaseLock`) – always runs (`finally`), records success/failure message and, on success, advances `lastSuccessfulRunDate` to the batch's end date so the next run resumes from there.
+It also builds per-form maps outside the time windows: total live/draft submissions per form, days-to-publish per form, and republish counts per form — these back the per-row columns in the overview table rather than the summary tiles. The resulting totals document is tagged with `language` if one was supplied. 7. **Persistence** (`updateMetricTotals`) – now takes an array of totals (one per language) and replaces all `TotalsMetric` and `DrilldownMetric` documents transactionally: existing totals/drilldown records are deleted, then for each language's totals, `saveDrilldown` extracts and stores each tile's `details` array as separate `DrilldownMetric` documents (tagged with the same `language`, to keep the totals document small), then the stripped-down totals are saved as their own `TotalsMetric` document. 8. **Unlocking** (`releaseLock`) – always runs (`finally`), records success/failure message and, on success, advances `lastSuccessfulRunDate` to the batch's end date so the next run resumes from there.
 
 All of collection runs inside a single Mongo `ClientSession`/transaction per batch (`session.withTransaction`), so a failed batch leaves previously-committed data untouched.
 
@@ -164,9 +171,9 @@ Defined in [`routes/report.js`](../src/routes/report.js). These routes only read
 ```mermaid
 flowchart LR
     subgraph Routes
-      R1[GET /report]
-      R2["GET /report/:formId"]
-      R3["GET /report/:period/:metricName"]
+      R1["GET /report?language="]
+      R2["GET /report/:formId?language="]
+      R3["GET /report/:period/:metricName/:language?"]
       R4[POST /report/regenerate]
     end
     R1 --> S1[generateReport]
@@ -175,34 +182,34 @@ flowchart LR
     R4 --> S4[clearMetricsDatabase + runMetricsCollectionJob]
 
     S1 --> D1[(OverviewMetric docs)]
-    S1 --> D2[(TotalsMetric doc)]
-    S2 --> D3[recalcMetrics over form's TimelineMetric docs]
-    S3 --> D4[(DrilldownMetric docs)]
+    S1 --> D2[(TotalsMetric doc, filtered by language)]
+    S2 --> D3[recalcMetrics over form's TimelineMetric docs, filtered by language]
+    S3 --> D4[(DrilldownMetric docs, filtered by language)]
 ```
 
 ### `GET /report`
 
 Handled by `generateReport(filter)`:
 
-- Fetches all `OverviewMetric` documents via `getAllOverviewMetrics`, optionally filtered by `searchText` (form name, case-insensitive regex), `status` (draft/live), `org` and `features` (all via query params validated by Joi).
-- Fetches the single `TotalsMetric` document via `getMetricTotals`.
+- Fetches all `OverviewMetric` documents via `getAllOverviewMetrics`, optionally filtered by `searchText` (form name, case-insensitive regex), `status` (draft/live), `org` and `language` (all via query params validated by Joi; `language` may only be `cy`, replacing the earlier `features` filter).
+- Fetches the `TotalsMetric` document for that `language` via `getMetricTotals(filter.language, session)`.
 - Calls `applyExtraColumns` to merge in `submissionsCount`, `daysToPublish` and `republished` (looked up per-form from the totals' per-form maps) into each overview row.
 - Returns `{ overview: [...], totals: {...} }` — `overview` drives the per-form table, `totals` drives the summary tiles.
 
 ### `GET /report/{formId}`
 
-Handled by `generateReportForForm(formId)`:
+Handled by `generateReportForForm(formId, language)` (`language` is an optional query param):
 
-- Instead of reading pre-aggregated totals, it re-runs `recalcMetrics` scoped to just that form's `TimelineMetric` documents (via `getFormTimelineMetricsCursor`), as of "yesterday", giving per-form windowed totals on demand.
-- Adds `earliestDate`/`updatedAt` from the global `TotalsMetric` document so the UI can show the overall reporting date range.
+- Instead of reading pre-aggregated totals, it re-runs `recalcMetrics` scoped to just that form's `TimelineMetric` documents for the given `language` (via `getFormTimelineMetricsCursor`), as of "yesterday", giving per-form windowed totals on demand.
+- Adds `earliestDate`/`updatedAt` from the matching-language `TotalsMetric` document so the UI can show the overall reporting date range.
 - Returns `{ totals: {...} }`.
 
-### `GET /report/{period}/{metricName}`
+### `GET /report/{period}/{metricName}/{language?}`
 
-Handled by `generateDrilldownReport(period, metricName)`:
+Handled by `generateDrilldownReport(period, metricName, language)` (`language` is now an optional path segment rather than a query param):
 
-- `period` must be one of `last7Days`, `last30Days`, `allTime` (the only periods drilldown was retained for); `metricName` must be a valid `FormMetricName`.
-- Reads matching `DrilldownMetric` documents via `getDrilldownRecords` and returns `{ drilldownRows: [...] }` — the list of individual events that make up a summary tile, for the "click a tile to see details" UI.
+- `period` must be one of `last7Days`, `last30Days`, `allTime` (the only periods drilldown was retained for); `metricName` must be a valid `FormMetricName`; `language`, if given, must be `cy`.
+- Reads matching `DrilldownMetric` documents via `getDrilldownRecords` (filtered by `language`) and returns `{ drilldownRows: [...] }` — the list of individual events that make up a summary tile, for the "click a tile to see details" UI.
 
 ### `POST /report/regenerate`
 
@@ -210,12 +217,13 @@ Admin-only (requires the `DeadLetterQueues` scope). Wipes all metrics data (`cle
 
 ## Key files
 
-| File                                                                                            | Responsibility                               |
-| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| [`src/routes/report.js`](../src/routes/report.js)                                               | HTTP routes, request validation              |
-| [`src/service/metrics.js`](../src/service/metrics.js)                                           | Core collection + reporting logic            |
-| [`src/service/metrics-helper.js`](../src/service/metrics-helper.js)                             | Metric calculation-type config, date helpers |
-| [`src/service/metrics-job.js`](../src/service/metrics-job.js)                                   | Job orchestration, locking, batching loop    |
-| [`src/plugins/cron.js`](../src/plugins/cron.js)                                                 | Schedules the job via `node-cron`            |
-| [`src/repositories/metrics-repository.js`](../src/repositories/metrics-repository.js)           | All Mongo reads/writes for metric documents  |
-| [`src/repositories/audit-record-repository.js`](../src/repositories/audit-record-repository.js) | Supplies audit-derived timeline metrics      |
+| File                                                                                            | Responsibility                                                            |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [`src/routes/report.js`](../src/routes/report.js)                                               | HTTP routes, request validation                                           |
+| [`src/service/metrics.js`](../src/service/metrics.js)                                           | Core collection + reporting logic                                         |
+| [`src/service/metrics-helper.js`](../src/service/metrics-helper.js)                             | Metric calculation-type config, date helpers                              |
+| [`src/service/metrics-job.js`](../src/service/metrics-job.js)                                   | Job orchestration, locking, batching loop                                 |
+| [`src/plugins/cron.js`](../src/plugins/cron.js)                                                 | Schedules the job via `node-cron`                                         |
+| [`src/repositories/metrics-repository.js`](../src/repositories/metrics-repository.js)           | All Mongo reads/writes for metric documents                               |
+| [`src/repositories/audit-record-repository.js`](../src/repositories/audit-record-repository.js) | Supplies audit-derived timeline metrics                                   |
+| [`src/constants.js`](../src/constants.js)                                                       | Defines the `CY` (Welsh) language code used throughout language filtering |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@aws-sdk/client-sqs": "3.1052.0",
         "@defra/cdp-auditing": "0.6.0",
-        "@defra/forms-model": "3.0.683",
+        "@defra/forms-model": "3.0.696",
         "@defra/hapi-tracing": "^1.26.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.4.6",
@@ -2099,9 +2099,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.683",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.683.tgz",
-      "integrity": "sha512-SMhWP0F1OwGiQGUY00/yLS5ddSwS1ZBYGIwyh/T+NWFSiA4t91d56smNOEc4R4H3+TusO2atspAJFbs/H4jbTg==",
+      "version": "3.0.696",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.696.tgz",
+      "integrity": "sha512-g9noP/nnba/Du4qx2sYNVWBUoD/3Ih5T275yyQrckGap2BWEjAM6JDsorvoTny05NovXSd6xUaQbAxeH95dJ0A==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "3.1052.0",
     "@defra/cdp-auditing": "0.6.0",
-    "@defra/forms-model": "3.0.683",
+    "@defra/forms-model": "3.0.696",
     "@defra/hapi-tracing": "^1.26.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.4.6",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const CY = 'cy'

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,1 @@
-export const CY = 'cy'
+export const WELSH = 'cy'

--- a/src/repositories/audit-record-repository.js
+++ b/src/repositories/audit-record-repository.js
@@ -117,16 +117,27 @@ export async function getConsolidatedAuditRecords(filter, pagination) {
  * Retrieve all the audit records of the particular type, from the specified date
  * @param {AuditEventMessageType} type
  * @param {Date} reportDate
+ * @param { Set<string> | undefined } formIdSet - optional list of form ids for restriction
  * @param {ClientSession} session
  * @param {Sort} [sort]
  * @returns {FindCursor<WithId<AuditRecordInput>>}
  */
-export function getAuditRecordsOfType(type, reportDate, session, sort) {
+export function getAuditRecordsOfType(
+  type,
+  reportDate,
+  formIdSet,
+  session,
+  sort
+) {
   const coll = getCollection()
 
   const withoutTime = reportDate.toISOString().substring(0, 10)
   const startOfDay = `${withoutTime}T00:00:00.000Z`
   const endOfDay = `${withoutTime}T23:59:59.999Z`
+
+  const formIdFilter = formIdSet
+    ? { entityId: { $in: Array.from(formIdSet) } }
+    : {}
 
   try {
     const cursor = /** @type {FindCursor<WithId<AuditRecordInput>>} */ (
@@ -137,7 +148,8 @@ export function getAuditRecordsOfType(type, reportDate, session, sort) {
             createdAt: {
               $gte: new Date(startOfDay),
               $lte: new Date(endOfDay)
-            }
+            },
+            ...formIdFilter
           },
           { session }
         )

--- a/src/repositories/audit-record-repository.test.js
+++ b/src/repositories/audit-record-repository.test.js
@@ -504,6 +504,7 @@ describe('audit-record-repository', () => {
       getAuditRecordsOfType(
         AuditEventMessageType.FORM_CREATED,
         testDate,
+        undefined,
         mockSession
       )
       expect(mockCollection.find).toHaveBeenCalledWith(
@@ -529,6 +530,7 @@ describe('audit-record-repository', () => {
         getAuditRecordsOfType(
           AuditEventMessageType.FORM_CREATED,
           testDate,
+          undefined,
           mockSession
         )
       ).toThrow('bad db call')

--- a/src/repositories/metrics-repository-helper.js
+++ b/src/repositories/metrics-repository-helper.js
@@ -1,0 +1,15 @@
+/**
+ * Creates a filter to query records with a specific language (or all records if language not provided)
+ * @param { string | undefined } language
+ */
+export function getLanguageFilter(language) {
+  return language ? { language } : {}
+}
+
+/**
+ * Creates a filter to query records with a specific language (or ONLY records that do NOT have a  language property)
+ * @param { string | undefined } language
+ */
+export function getLanguageNoPropertyFilter(language) {
+  return language ? { language } : { language: { $exists: false } }
+}

--- a/src/repositories/metrics-repository-helper.js
+++ b/src/repositories/metrics-repository-helper.js
@@ -1,3 +1,5 @@
+import { METRICS_COLLECTION_NAME, db } from '~/src/mongo.js'
+
 /**
  * Creates a filter to query records with a specific language (or all records if language not provided)
  * @param { string | undefined } language
@@ -13,3 +15,19 @@ export function getLanguageFilter(language) {
 export function getLanguageNoPropertyFilter(language) {
   return language ? { language } : { language: { $exists: false } }
 }
+
+/**
+ * Gets the metric collection
+ * @returns {Collection<FormOverviewMetric | FormTimelineMetric | FormTotalsMetric | FormDrilldownMetric | FormMetricControl>}
+ */
+export function getMetricCollection() {
+  return /** @type {Collection<FormOverviewMetric | FormTimelineMetric | FormTotalsMetric | FormDrilldownMetric | FormMetricControl>} */ (
+    db.collection(METRICS_COLLECTION_NAME)
+  )
+}
+
+/**
+ * @import { Collection } from 'mongodb'
+ * @import { FormOverviewMetric, FormTimelineMetric, FormTotalsMetric, FormDrilldownMetric } from '@defra/forms-model'
+ * @import { FormMetricControl } from '~/src/service/metrics.js'
+ */

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -2,24 +2,14 @@ import { FormMetricName, FormMetricType, FormStatus } from '@defra/forms-model'
 
 import { getErrorMessage } from '~/src/helpers/error-message.js'
 import { logger } from '~/src/helpers/logging/logger.js'
-import { METRICS_COLLECTION_NAME, db } from '~/src/mongo.js'
 import {
   getLanguageFilter,
-  getLanguageNoPropertyFilter
+  getLanguageNoPropertyFilter,
+  getMetricCollection
 } from '~/src/repositories/metrics-repository-helper.js'
 import { metricDrilldownPeriods } from '~/src/service/metrics-helper.js'
 
 const FORM_METRIC_CONTROL = 'form-metric-control'
-
-/**
- * Gets the metric collection
- * @returns {Collection<FormOverviewMetric | FormTimelineMetric | FormTotalsMetric | FormDrilldownMetric | FormMetricControl>}
- */
-function getMetricCollection() {
-  return /** @type {Collection<FormOverviewMetric | FormTimelineMetric | FormTotalsMetric | FormDrilldownMetric | FormMetricControl>} */ (
-    db.collection(METRICS_COLLECTION_NAME)
-  )
-}
 
 /**
  * Gets overview metric records for a form.

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -16,6 +16,14 @@ export function getLanguageFilter(language) {
 }
 
 /**
+ * Creates a filter to query records with a specific language (or ONLY records that do NOT have a  language property)
+ * @param { string | undefined } language
+ */
+export function getLanguageNoPropertyFilter(language) {
+  return language ? { language } : { language: { $exists: false } }
+}
+
+/**
  * Gets the metric collection
  * @returns {Collection<FormOverviewMetric | FormTimelineMetric | FormTotalsMetric | FormDrilldownMetric | FormMetricControl>}
  */
@@ -523,9 +531,7 @@ export async function getNumberOfFormsInDraft(
   const startOfDay = `${withoutTime}T00:00:00.000Z`
   const endOfDay = `${withoutTime}T23:59:59.999Z`
 
-  const languageFilter = language
-    ? { language }
-    : { language: { $exists: false } }
+  const languageFilter = getLanguageNoPropertyFilter(language)
 
   try {
     const numberOfDrafts =

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -8,6 +8,14 @@ import { metricDrilldownPeriods } from '~/src/service/metrics-helper.js'
 const FORM_METRIC_CONTROL = 'form-metric-control'
 
 /**
+ * Creates a filter to query records with a specific language (or all records if language not provided)
+ * @param { string | undefined } language
+ */
+export function getLanguageFilter(language) {
+  return language ? { language } : {}
+}
+
+/**
  * Gets the metric collection
  * @returns {Collection<FormOverviewMetric | FormTimelineMetric | FormTotalsMetric | FormDrilldownMetric | FormMetricControl>}
  */
@@ -120,17 +128,25 @@ export async function deleteFormOverviewMetrics(session) {
 /**
  * Gets overview metric records for a form.
  * @param {string} formId
+ * @param { string | undefined } language
  * @param {ClientSession} session
  * @returns {FindCursor<WithId<FormTimelineMetric>>}
  */
-export function getFormTimelineMetricsCursor(formId, session) {
+export function getFormTimelineMetricsCursor(formId, language, session) {
   const coll = getMetricCollection()
 
   try {
     const timelineRecords =
       /** @type {FindCursor<WithId<FormTimelineMetric>>} */ (
         coll
-          .find({ formId, type: FormMetricType.TimelineMetric }, { session })
+          .find(
+            {
+              formId,
+              type: FormMetricType.TimelineMetric,
+              ...getLanguageFilter(language)
+            },
+            { session }
+          )
           .sort({ createdAt: -1 })
       )
     return timelineRecords
@@ -146,11 +162,12 @@ export function getFormTimelineMetricsCursor(formId, session) {
 /**
  * Gets overview metric records for a form.
  * @param {string} formId
+ * @param { string | undefined } language
  * @param {ClientSession} session
  * @returns {Promise<WithId<FormTimelineMetric>[]>}
  */
-export async function getFormTimelineMetrics(formId, session) {
-  return getFormTimelineMetricsCursor(formId, session).toArray()
+export async function getFormTimelineMetrics(formId, language, session) {
+  return getFormTimelineMetricsCursor(formId, language, session).toArray()
 }
 
 /**
@@ -174,9 +191,7 @@ export function getAllOverviewMetrics(filter, session) {
     ? { 'summaryMetrics.organisation': { $in: filter.org } }
     : {}
 
-  const filterPart4 = filter.features
-    ? { 'summaryMetrics.features': { $in: filter.features } }
-    : {}
+  const filterPart4 = filter.language ? { language: filter.language } : {}
 
   try {
     const cursor = /** @type {FindCursor<WithId<FormOverviewMetric>>} */ (
@@ -205,16 +220,23 @@ export function getAllOverviewMetrics(filter, session) {
 
 /**
  * Get all timeline metrics
+ * @param { string | undefined } language
  * @param {ClientSession} session
  * @returns {FindCursor<WithId<FormTimelineMetric>>}
  */
-export function getAllTimelineMetrics(session) {
+export function getAllTimelineMetrics(language, session) {
   const coll = getMetricCollection()
 
   try {
     const cursor = /** @type {FindCursor<WithId<FormTimelineMetric>>} */ (
       coll
-        .find({ type: FormMetricType.TimelineMetric }, { session })
+        .find(
+          {
+            type: FormMetricType.TimelineMetric,
+            ...getLanguageFilter(language)
+          },
+          { session }
+        )
         .sort({ updatedAt: -1 })
     )
     return cursor
@@ -256,14 +278,18 @@ export async function saveFormTimelineMetrics(formId, metricData, session) {
 
 /**
  * Gets metric totals record.
+ * @param { string | undefined } language
  * @param {ClientSession} session
  */
-export function getMetricTotals(session) {
+export function getMetricTotals(language, session) {
   const coll = getMetricCollection()
 
   try {
     return /** @type {Promise<WithId<FormTotalsMetric>>} */ (
-      coll.findOne({ type: FormMetricType.TotalsMetric }, { session })
+      coll.findOne(
+        { type: FormMetricType.TotalsMetric, ...getLanguageFilter(language) },
+        { session }
+      )
     )
   } catch (err) {
     logger.error(err, `Failed to get totals metric - ${getErrorMessage(err)}`)
@@ -275,9 +301,15 @@ export function getMetricTotals(session) {
  * Gets metric drilldown records.
  * @param {string} periodName
  * @param {FormMetricName} metricName
+ * @param { string | undefined } language
  * @param {ClientSession} session
  */
-export async function getDrilldownRecords(periodName, metricName, session) {
+export async function getDrilldownRecords(
+  periodName,
+  metricName,
+  language,
+  session
+) {
   const coll = getMetricCollection()
 
   try {
@@ -287,7 +319,8 @@ export async function getDrilldownRecords(periodName, metricName, session) {
           {
             type: FormMetricType.DrilldownMetric,
             periodName,
-            metricName
+            metricName,
+            ...getLanguageFilter(language)
           },
           { session }
         )
@@ -305,28 +338,30 @@ export async function getDrilldownRecords(periodName, metricName, session) {
 /**
  * Saves snapshot metric records for a form.
  * @param {Date} reportDate
- * @param {FormTotalsMetric} totals
+ * @param {FormTotalsMetric[]} totalsList
  * @param {ClientSession} session
  */
-export async function updateMetricTotals(reportDate, totals, session) {
+export async function updateMetricTotals(reportDate, totalsList, session) {
   const coll = getMetricCollection()
 
   try {
     await coll.deleteMany({ type: FormMetricType.TotalsMetric }, { session })
     await coll.deleteMany({ type: FormMetricType.DrilldownMetric }, { session })
 
-    // Extract drilldown detail from 'totals' data, and save as drilldown records
-    totals = await saveDrilldown(totals, session)
-    totals.updatedAt = reportDate
+    for (let totals of totalsList) {
+      // Extract drilldown detail from 'totals' data, and save as drilldown records
+      totals = await saveDrilldown(totals, session)
+      totals.updatedAt = reportDate
 
-    // Now save 'totals' records with drilldown data removed
-    await coll.insertOne(
-      {
-        ...totals,
-        type: FormMetricType.TotalsMetric
-      },
-      { session }
-    )
+      // Now save 'totals' records with drilldown data removed
+      await coll.insertOne(
+        {
+          ...totals,
+          type: FormMetricType.TotalsMetric
+        },
+        { session }
+      )
+    }
   } catch (err) {
     logger.error(err, `Failed to save totals metric - ${getErrorMessage(err)}`)
     throw err
@@ -350,6 +385,12 @@ export async function saveDrilldown(totals, session) {
       const detail = period[metricName]
       if ('details' in detail) {
         const details = /** @type {FormDrilldownMetric[]} */ (detail.details)
+        // Add 'language' property if supplied in the 'totals' record
+        if (totals.language) {
+          details.forEach((detail) => {
+            detail.language = totals.language
+          })
+        }
         await saveDrilldownRecords(
           periodName,
           /** @type {FormMetricName} */ (metricName),
@@ -467,15 +508,24 @@ export async function getFirstDraft(formId, session) {
 /**
  * Gets the 'forms in draft' metric for the specified date and returns the value
  * @param {Date} reportingDate
+ * @param { string | undefined } language
  * @param {ClientSession} session
  * @returns {Promise<number>}
  */
-export async function getNumberOfFormsInDraft(reportingDate, session) {
+export async function getNumberOfFormsInDraft(
+  reportingDate,
+  language,
+  session
+) {
   const coll = getMetricCollection()
 
   const withoutTime = reportingDate.toISOString().substring(0, 10)
   const startOfDay = `${withoutTime}T00:00:00.000Z`
   const endOfDay = `${withoutTime}T23:59:59.999Z`
+
+  const languageFilter = language
+    ? { language }
+    : { language: { $exists: false } }
 
   try {
     const numberOfDrafts =
@@ -487,7 +537,8 @@ export async function getNumberOfFormsInDraft(reportingDate, session) {
             createdAt: {
               $gte: new Date(startOfDay),
               $lte: new Date(endOfDay)
-            }
+            },
+            ...languageFilter
           },
           { session }
         )

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -191,7 +191,7 @@ export function getAllOverviewMetrics(filter, session) {
     ? { 'summaryMetrics.organisation': { $in: filter.org } }
     : {}
 
-  const filterPart4 = filter.language ? { language: filter.language } : {}
+  const filterPart4 = getLanguageFilter(filter.language)
 
   try {
     const cursor = /** @type {FindCursor<WithId<FormOverviewMetric>>} */ (

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -174,6 +174,10 @@ export function getAllOverviewMetrics(filter, session) {
     ? { 'summaryMetrics.organisation': { $in: filter.org } }
     : {}
 
+  const filterPart4 = filter.features
+    ? { 'summaryMetrics.features': { $in: filter.features } }
+    : {}
+
   try {
     const cursor = /** @type {FindCursor<WithId<FormOverviewMetric>>} */ (
       coll
@@ -182,7 +186,8 @@ export function getAllOverviewMetrics(filter, session) {
             type: FormMetricType.OverviewMetric,
             ...filterPart1,
             ...filterPart2,
-            ...filterPart3
+            ...filterPart3,
+            ...filterPart4
           },
           { session }
         )

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -3,25 +3,13 @@ import { FormMetricName, FormMetricType, FormStatus } from '@defra/forms-model'
 import { getErrorMessage } from '~/src/helpers/error-message.js'
 import { logger } from '~/src/helpers/logging/logger.js'
 import { METRICS_COLLECTION_NAME, db } from '~/src/mongo.js'
+import {
+  getLanguageFilter,
+  getLanguageNoPropertyFilter
+} from '~/src/repositories/metrics-repository-helper.js'
 import { metricDrilldownPeriods } from '~/src/service/metrics-helper.js'
 
 const FORM_METRIC_CONTROL = 'form-metric-control'
-
-/**
- * Creates a filter to query records with a specific language (or all records if language not provided)
- * @param { string | undefined } language
- */
-export function getLanguageFilter(language) {
-  return language ? { language } : {}
-}
-
-/**
- * Creates a filter to query records with a specific language (or ONLY records that do NOT have a  language property)
- * @param { string | undefined } language
- */
-export function getLanguageNoPropertyFilter(language) {
-  return language ? { language } : { language: { $exists: false } }
-}
 
 /**
  * Gets the metric collection
@@ -395,8 +383,8 @@ export async function saveDrilldown(totals, session) {
         const details = /** @type {FormDrilldownMetric[]} */ (detail.details)
         // Add 'language' property if supplied in the 'totals' record
         if (totals.language) {
-          details.forEach((detail) => {
-            detail.language = totals.language
+          details.forEach((det) => {
+            det.language = totals.language
           })
         }
         await saveDrilldownRecords(

--- a/src/repositories/metrics-repository.test.js
+++ b/src/repositories/metrics-repository.test.js
@@ -206,7 +206,11 @@ describe('metrics-repository', () => {
         })
       })
 
-      const result = await getFormTimelineMetrics(formId, mockSession)
+      const result = await getFormTimelineMetrics(
+        formId,
+        undefined,
+        mockSession
+      )
 
       expect(result).toEqual([draftDoc, liveDoc])
     })
@@ -217,7 +221,7 @@ describe('metrics-repository', () => {
       })
 
       await expect(() =>
-        getFormTimelineMetrics(formId, mockSession)
+        getFormTimelineMetrics(formId, undefined, mockSession)
       ).rejects.toThrow('db error')
     })
   })
@@ -472,7 +476,7 @@ describe('metrics-repository', () => {
           return { cursor: {} }
         })
       })
-      const res = getAllTimelineMetrics(mockSession)
+      const res = getAllTimelineMetrics(undefined, mockSession)
       expect(res).toEqual({ cursor: {} })
     })
 
@@ -482,12 +486,14 @@ describe('metrics-repository', () => {
           throw new Error('bad find')
         })
       })
-      expect(() => getAllTimelineMetrics(mockSession)).toThrow('bad find')
+      expect(() => getAllTimelineMetrics(undefined, mockSession)).toThrow(
+        'bad find'
+      )
     })
 
     it('should get metrics totals', () => {
       mockCollection.findOne.mockReturnValueOnce({ cursor: {} })
-      const res = getMetricTotals(mockSession)
+      const res = getMetricTotals(undefined, mockSession)
       expect(res).toEqual({ cursor: {} })
     })
 
@@ -495,7 +501,9 @@ describe('metrics-repository', () => {
       mockCollection.findOne.mockImplementationOnce(() => {
         throw new Error('Bad cursor')
       })
-      expect(() => getMetricTotals(mockSession)).toThrow('Bad cursor')
+      expect(() => getMetricTotals(undefined, mockSession)).toThrow(
+        'Bad cursor'
+      )
     })
   })
 
@@ -593,6 +601,7 @@ describe('metrics-repository', () => {
       const res = await getDrilldownRecords(
         'last7Days',
         FormMetricName.NewFormsCreated,
+        undefined,
         mockSession
       )
       expect(res).toEqual([{ drill1: 123 }, { drill2: 456 }])
@@ -614,6 +623,7 @@ describe('metrics-repository', () => {
         getDrilldownRecords(
           'last7Days',
           FormMetricName.NewFormsCreated,
+          undefined,
           mockSession
         )
       ).rejects.toThrow('bad db call')
@@ -625,7 +635,11 @@ describe('metrics-repository', () => {
 
     it('should return number from specific date', async () => {
       mockCollection.findOne.mockResolvedValueOnce({ metricValue: 5 })
-      const res = await getNumberOfFormsInDraft(testDate, mockSession)
+      const res = await getNumberOfFormsInDraft(
+        testDate,
+        undefined,
+        mockSession
+      )
       expect(res).toBe(5)
       expect(mockCollection.findOne).toHaveBeenCalledWith(
         {
@@ -642,7 +656,11 @@ describe('metrics-repository', () => {
 
     it('should return zero if not found', async () => {
       mockCollection.findOne.mockResolvedValueOnce({})
-      const res = await getNumberOfFormsInDraft(testDate, mockSession)
+      const res = await getNumberOfFormsInDraft(
+        testDate,
+        undefined,
+        mockSession
+      )
       expect(res).toBe(0)
       expect(mockCollection.findOne).toHaveBeenCalledWith(
         {
@@ -662,7 +680,7 @@ describe('metrics-repository', () => {
         throw new Error('bad db call')
       })
       await expect(() =>
-        getNumberOfFormsInDraft(testDate, mockSession)
+        getNumberOfFormsInDraft(testDate, undefined, mockSession)
       ).rejects.toThrow('bad db call')
     })
   })

--- a/src/repositories/metrics-repository.test.js
+++ b/src/repositories/metrics-repository.test.js
@@ -3,6 +3,10 @@ import { FormMetricName, FormMetricType, FormStatus } from '@defra/forms-model'
 import { buildMockCollection } from '~/src/api/forms/__stubs__/mongo.js'
 import { db } from '~/src/mongo.js'
 import {
+  getLanguageFilter,
+  getLanguageNoPropertyFilter
+} from '~/src/repositories/metrics-repository-helper.js'
+import {
   clearMetricsData,
   deleteFormOverviewMetrics,
   getAllOverviewMetrics,
@@ -11,8 +15,6 @@ import {
   getFirstDraft,
   getFormOverviewMetrics,
   getFormTimelineMetrics,
-  getLanguageFilter,
-  getLanguageNoPropertyFilter,
   getMetricTotals,
   getNumberOfFormsInDraft,
   grabLock,
@@ -801,6 +803,40 @@ describe('metrics-repository', () => {
       expect(mockCollection.insertMany).toHaveBeenCalledTimes(3)
     })
 
+    it('should save a batch of drilldown records with language property', async () => {
+      const totalsCopy = /** @type {FormTotalsMetric} */ (
+        /** @type {unknown} */ (structuredClone(totals))
+      )
+      totalsCopy.language = 'cy'
+      await saveDrilldown(totalsCopy, mockSession)
+
+      expect(mockCollection.insertMany).toHaveBeenCalledTimes(3)
+      expect(mockCollection.insertMany).toHaveBeenNthCalledWith(
+        1,
+        [
+          {
+            createdAt: expect.anything(),
+            formId: 'form-id-1',
+            language: 'cy',
+            metricName: 'NewFormsCreated',
+            metricValue: 1,
+            periodName: 'last7Days',
+            type: 'drilldown-metric'
+          },
+          {
+            createdAt: expect.anything(),
+            formId: 'form-id-2',
+            language: 'cy',
+            metricName: 'NewFormsCreated',
+            metricValue: 1,
+            periodName: 'last7Days',
+            type: 'drilldown-metric'
+          }
+        ],
+        expect.anything()
+      )
+    })
+
     it('should throw if error', async () => {
       const totalsCopy = structuredClone(totals)
       mockCollection.insertMany.mockImplementationOnce(() => {
@@ -865,5 +901,5 @@ describe('metrics-repository', () => {
 })
 
 /**
- * @import { FormOverviewMetric, FormTimelineMetric } from '@defra/forms-model'
+ * @import { FormOverviewMetric, FormTimelineMetric, FormTotalsMetric } from '@defra/forms-model'
  */

--- a/src/repositories/metrics-repository.test.js
+++ b/src/repositories/metrics-repository.test.js
@@ -263,7 +263,7 @@ describe('metrics-repository', () => {
       mockCollection.insertOne.mockResolvedValueOnce({})
 
       // @ts-expect-error - partial data mocked
-      await updateMetricTotals(new Date(), totals, mockSession)
+      await updateMetricTotals(new Date(), [totals], mockSession)
 
       expect(mockCollection.insertOne).toHaveBeenCalledWith(
         {
@@ -291,7 +291,7 @@ describe('metrics-repository', () => {
 
       await expect(() =>
         // @ts-expect-error - partial data mocked
-        updateMetricTotals(new Date(), totals, mockSession)
+        updateMetricTotals(new Date(), [totals], mockSession)
       ).rejects.toThrow('db error')
     })
   })
@@ -648,6 +648,9 @@ describe('metrics-repository', () => {
           createdAt: {
             $gte: new Date('2026-04-01T00:00:00.000Z'),
             $lte: new Date('2026-04-01T23:59:59.999Z')
+          },
+          language: {
+            $exists: false
           }
         },
         { session: {} }
@@ -669,6 +672,9 @@ describe('metrics-repository', () => {
           createdAt: {
             $gte: new Date('2026-04-01T00:00:00.000Z'),
             $lte: new Date('2026-04-01T23:59:59.999Z')
+          },
+          language: {
+            $exists: false
           }
         },
         { session: {} }

--- a/src/repositories/metrics-repository.test.js
+++ b/src/repositories/metrics-repository.test.js
@@ -11,6 +11,8 @@ import {
   getFirstDraft,
   getFormOverviewMetrics,
   getFormTimelineMetrics,
+  getLanguageFilter,
+  getLanguageNoPropertyFilter,
   getMetricTotals,
   getNumberOfFormsInDraft,
   grabLock,
@@ -838,6 +840,26 @@ describe('metrics-repository', () => {
           mockSession
         )
       ).rejects.toThrow('bad db call')
+    })
+  })
+
+  describe('getLanguageFilter', () => {
+    it('should return filter to restrict to specific language', () => {
+      expect(getLanguageFilter('cy')).toEqual({ language: 'cy' })
+    })
+    it('should return empty filter', () => {
+      expect(getLanguageFilter(undefined)).toEqual({})
+    })
+  })
+
+  describe('getLanguageNoPropertyFilter', () => {
+    it('should return filter to restrict to specific language', () => {
+      expect(getLanguageNoPropertyFilter('cy')).toEqual({ language: 'cy' })
+    })
+    it('should return filter to look for records witout a language property', () => {
+      expect(getLanguageNoPropertyFilter(undefined)).toEqual({
+        language: { $exists: false }
+      })
     })
   })
 })

--- a/src/routes/report.js
+++ b/src/routes/report.js
@@ -17,7 +17,8 @@ const filteringSchema = Joi.object({
     .items(Joi.string().valid('draft', 'live'))
     .single()
     .optional(),
-  org: Joi.array().items(Joi.string()).single().optional()
+  org: Joi.array().items(Joi.string()).single().optional(),
+  features: Joi.array().items(Joi.string()).single().optional()
 })
 
 const paramSchema = Joi.object({

--- a/src/routes/report.js
+++ b/src/routes/report.js
@@ -1,6 +1,7 @@
 import { FormMetricName, Scopes } from '@defra/forms-model'
 import Joi from 'joi'
 
+import { CY } from '~/src/constants.js'
 import { runMetricsCollectionJob } from '~/src/service/metrics-job.js'
 import {
   clearMetricsDatabase,
@@ -18,18 +19,23 @@ const filteringSchema = Joi.object({
     .single()
     .optional(),
   org: Joi.array().items(Joi.string()).single().optional(),
-  features: Joi.array().items(Joi.string()).single().optional()
+  language: Joi.string().allow(CY).optional()
 })
 
 const paramSchema = Joi.object({
   formId: Joi.string().required()
 })
 
+const querySchema = Joi.object({
+  language: Joi.string().allow(CY).optional()
+})
+
 const drilldownSchema = Joi.object({
   period: Joi.string().valid('last7Days', 'last30Days', 'allTime').required(),
   metricName: Joi.string()
     .valid(...Object.values(FormMetricName))
-    .required()
+    .required(),
+  language: Joi.string().allow(CY).optional()
 })
 
 export default [
@@ -54,36 +60,38 @@ export default [
   }),
 
   /**
-   * @satisfies {ServerRoute}
+   * @satisfies {ServerRoute< { Param: { formId: string }, Query: { language?: string } }>}
    */
   ({
     method: 'GET',
     path: '/report/{formId}',
     async handler(request, h) {
-      const { params } = request
-      const metrics = await generateReportForForm(params.formId)
+      const { params, query } = request
+      const metrics = await generateReportForForm(params.formId, query.language)
 
       return h.response(metrics).code(HTTP_OK)
     },
     options: {
       auth: false,
       validate: {
-        params: paramSchema
+        params: paramSchema,
+        query: querySchema
       }
     }
   }),
 
   /**
-   * @satisfies {ServerRoute<{ Params: { period: string, metricName: FormMetricName } }>}
+   * @satisfies {ServerRoute<{ Params: { period: string, metricName: FormMetricName, language?: string }, Query: { language?: string } }>}
    */
   ({
     method: 'GET',
-    path: '/report/{period}/{metricName}',
+    path: '/report/{period}/{metricName}/{language?}',
     async handler(request, h) {
       const { params } = request
       const metrics = await generateDrilldownReport(
         params.period,
-        params.metricName
+        params.metricName,
+        params.language
       )
 
       return h.response(metrics).code(HTTP_OK)
@@ -91,7 +99,8 @@ export default [
     options: {
       auth: false,
       validate: {
-        params: drilldownSchema
+        params: drilldownSchema,
+        query: querySchema
       }
     }
   }),

--- a/src/routes/report.js
+++ b/src/routes/report.js
@@ -1,7 +1,7 @@
 import { FormMetricName, Scopes } from '@defra/forms-model'
 import Joi from 'joi'
 
-import { CY } from '~/src/constants.js'
+import { WELSH } from '~/src/constants.js'
 import { runMetricsCollectionJob } from '~/src/service/metrics-job.js'
 import {
   clearMetricsDatabase,
@@ -19,7 +19,7 @@ const filteringSchema = Joi.object({
     .single()
     .optional(),
   org: Joi.array().items(Joi.string()).single().optional(),
-  language: Joi.string().allow(CY).optional()
+  language: Joi.string().allow(WELSH).optional()
 })
 
 const paramSchema = Joi.object({
@@ -27,7 +27,7 @@ const paramSchema = Joi.object({
 })
 
 const querySchema = Joi.object({
-  language: Joi.string().allow(CY).optional()
+  language: Joi.string().allow(WELSH).optional()
 })
 
 const drilldownSchema = Joi.object({
@@ -35,7 +35,7 @@ const drilldownSchema = Joi.object({
   metricName: Joi.string()
     .valid(...Object.values(FormMetricName))
     .required(),
-  language: Joi.string().allow(CY).optional()
+  language: Joi.string().allow(WELSH).optional()
 })
 
 export default [

--- a/src/service/metrics-helper.js
+++ b/src/service/metrics-helper.js
@@ -104,5 +104,107 @@ export function createFormMap(metricValues) {
 }
 
 /**
+ * @param {FormTimelineMetric} metric
+ * @param { Record<string, { count?: number }> | undefined } period
+ * @param {string} calculationType
+ * @param {boolean} [saveDrilldown]
+ */
+export function handleMetricValue(
+  metric,
+  period,
+  calculationType,
+  saveDrilldown
+) {
+  if (calculationType === CalculationTypes.AccumulationWithDrilldown) {
+    updateMetricTotal(metric, period, saveDrilldown)
+  }
+  if (calculationType === CalculationTypes.Accumulation) {
+    updateMetricTotal(metric, period)
+  }
+  if (calculationType === CalculationTypes.Snapshot) {
+    setMetricTotal(metric, period)
+  }
+  if (calculationType === CalculationTypes.Average) {
+    updateMetricAverage(metric, period)
+  }
+}
+
+/**
+ * @param {FormTimelineMetric} metric
+ * @param { Record<string, { count?: number, details?: FormTimelineMetric[] }> | undefined } period
+ * @param {boolean} [drillDown]
+ */
+export function updateMetricTotal(metric, period, drillDown) {
+  const metricName = metric.metricName
+  if (
+    !period ||
+    (metric.metricName === FormMetricName.Submissions &&
+      metric.formStatus !== FormStatus.Live)
+  ) {
+    return
+  }
+  if (metricName in period && 'count' in period[metricName]) {
+    const currentTotal = period[metricName].count ?? 0
+    const newTotal = currentTotal + metric.metricValue
+    const detail = drillDown
+      ? {
+          details: [...(period[metricName].details ?? []), mapToMinimal(metric)]
+        }
+      : {}
+    period[metricName] = { count: newTotal, ...detail }
+  } else {
+    const detail = drillDown ? { details: [mapToMinimal(metric)] } : {}
+    period[metricName] = { count: metric.metricValue, ...detail }
+  }
+}
+
+/**
+ * Remove unwanted properties (reduces the overall document size)
+ * @param {FormTimelineMetric} detail
+ */
+function mapToMinimal(detail) {
+  return /** @type {FormTimelineMetric} */ ({
+    formId: detail.formId,
+    metricValue: detail.metricValue,
+    createdAt: detail.createdAt
+  })
+}
+
+/**
+ * @param {FormTimelineMetric} metric
+ * @param { Record<string, { count?: number }> | undefined } period
+ */
+export function setMetricTotal(metric, period) {
+  if (!period) {
+    return
+  }
+  const metricName = metric.metricName
+  period[metricName] = { count: metric.metricValue }
+}
+
+/**
+ * @param {FormTimelineMetric} metric
+ * @param { Record<string, { count?: number, avgTotal?: number, avgCount?: number }> | undefined } period
+ */
+export function updateMetricAverage(metric, period) {
+  const metricName = metric.metricName
+  if (!period) {
+    return
+  }
+  if (
+    metricName in period &&
+    'avgTotal' in period[metricName] &&
+    'avgCount' in period[metricName]
+  ) {
+    const currentAvgTotal = period[metricName].avgTotal ?? 0
+    const currentAvgCount = period[metricName].avgCount ?? 0
+    period[metricName].avgTotal = currentAvgTotal + metric.metricValue
+    period[metricName].avgCount = currentAvgCount + 1
+  } else {
+    period[metricName] = { avgTotal: metric.metricValue, avgCount: 1 }
+  }
+}
+
+/**
  * @import { FormTimelineMetric } from '@defra/forms-model'
  */

--- a/src/service/metrics-helper.test.js
+++ b/src/service/metrics-helper.test.js
@@ -1,4 +1,10 @@
-import { setTimeOnDate } from '~/src/service/metrics-helper.js'
+import { FormMetricName, FormStatus } from '@defra/forms-model'
+
+import {
+  CalculationTypes,
+  handleMetricValue,
+  setTimeOnDate
+} from '~/src/service/metrics-helper.js'
 
 describe('metrics-helper', () => {
   describe('setTimeOnDate', () => {
@@ -8,4 +14,76 @@ describe('metrics-helper', () => {
       expect(setTimeOnDate(testDateStr, expectedDate)).toEqual(expectedDate)
     })
   })
+
+  describe('handleMetricValue', () => {
+    it('should handle accumulation with drilldown', () => {
+      const metric = /** @type {FormTimelineMetric} */ ({
+        metricName: FormMetricName.Submissions,
+        formStatus: FormStatus.Live,
+        metricValue: 5
+      })
+      const period = { Submissions: { count: 1 } }
+      handleMetricValue(
+        metric,
+        period,
+        CalculationTypes.AccumulationWithDrilldown
+      )
+      expect(period).toEqual({
+        Submissions: {
+          count: 6
+        }
+      })
+    })
+
+    it('should handle accumulation', () => {
+      const metric = /** @type {FormTimelineMetric} */ ({
+        metricName: FormMetricName.FormsInDraft,
+        formStatus: FormStatus.Live,
+        metricValue: 3
+      })
+      const period = { FormsInDraft: { count: 1 } }
+      handleMetricValue(metric, period, CalculationTypes.Accumulation)
+      expect(period).toEqual({
+        FormsInDraft: {
+          count: 4
+        }
+      })
+    })
+
+    it('should handle snapshot', () => {
+      const metric = /** @type {FormTimelineMetric} */ ({
+        metricName: FormMetricName.TimeToPublish,
+        formStatus: FormStatus.Live,
+        metricValue: 3
+      })
+      const period = { TimeToPublish: { count: 7 } }
+      handleMetricValue(metric, period, CalculationTypes.Snapshot)
+      expect(period).toEqual({
+        TimeToPublish: {
+          count: 3
+        }
+      })
+    })
+
+    it('should handle average', () => {
+      const metric = /** @type {FormTimelineMetric} */ ({
+        metricName: FormMetricName.TimeToPublish,
+        formStatus: FormStatus.Live,
+        metricValue: 3
+      })
+      const period = { TimeToPublish: { avgCount: 1, avgTotal: 15 } }
+      // @ts-expect-error - partial mock of data
+      handleMetricValue(metric, period, CalculationTypes.Average)
+      expect(period).toEqual({
+        TimeToPublish: {
+          avgCount: 2,
+          avgTotal: 18
+        }
+      })
+    })
+  })
 })
+
+/**
+ * @import { FormTimelineMetric } from '@defra/forms-model'
+ */

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -15,7 +15,7 @@ import {
 } from 'date-fns'
 
 import { config } from '~/src/config/index.js'
-import { CY } from '~/src/constants.js'
+import { WELSH } from '~/src/constants.js'
 import { logger } from '~/src/helpers/logging/logger.js'
 import { getJson } from '~/src/lib/fetch.js'
 import { client } from '~/src/mongo.js'
@@ -28,6 +28,7 @@ import {
   getDrilldownRecords,
   getFirstDraft,
   getFormTimelineMetricsCursor,
+  getLanguageFilter,
   getMetricTotals,
   getNumberOfFormsInDraft,
   isFirstPublish,
@@ -135,7 +136,7 @@ export async function collectMetrics(
     // All languages
     await collectTimelineMetrics(submissionUrl, reportDate, undefined, session)
     // Welsh-only
-    await collectTimelineMetrics(submissionUrl, reportDate, CY, session)
+    await collectTimelineMetrics(submissionUrl, reportDate, WELSH, session)
 
     // All languages
     await collectTimelineMetricsFromAudit(
@@ -147,7 +148,7 @@ export async function collectMetrics(
     // Welsh-only
     await collectTimelineMetricsFromAudit(
       reportDate,
-      CY,
+      WELSH,
       languageFormIds,
       session
     )
@@ -156,10 +157,14 @@ export async function collectMetrics(
   }
 
   const totals = [
+    // All languages
     await recalcMetrics(reportEndDate, undefined, session),
-    await recalcMetrics(reportEndDate, CY, session)
+    // Welsh-only
+    await recalcMetrics(reportEndDate, WELSH, session)
   ]
+
   await updateMetricTotals(reportEndDate, totals, session)
+
   return {
     success: true,
     message: 'Completed ok',
@@ -290,7 +295,7 @@ export async function collectTimelineMetricsFromAudit(
   languageFormIds,
   session
 ) {
-  const languageProp = language ? { language } : {}
+  const languageProp = getLanguageFilter(language)
 
   // Read 'forms in draft without a live form' so far from previous day
   let numOfFormsNotLive = await getNumberOfFormsInDraft(
@@ -329,9 +334,10 @@ export async function collectTimelineMetricsFromAudit(
   )
   for await (const publish of publishCursor) {
     // Check if first publish
-    const firstPublish = languageFormIds?.liveIds?.has(publish.entityId)
-      ? await isFirstPublish(publish.entityId, session)
-      : undefined
+    const firstPublish =
+      !languageFormIds || languageFormIds.liveIds?.has(publish.entityId)
+        ? await isFirstPublish(publish.entityId, session)
+        : undefined
     if (firstPublish) {
       // Time to first publish
       numOfFormsNotLive--
@@ -345,9 +351,10 @@ export async function collectTimelineMetricsFromAudit(
       })
       await saveFormTimelineMetrics(publish.entityId, metricPublish, session)
 
-      const firstDraft = languageFormIds?.draftIds?.has(publish.entityId)
-        ? await getFirstDraft(publish.entityId, session)
-        : undefined
+      const firstDraft =
+        !languageFormIds || languageFormIds.draftIds?.has(publish.entityId)
+          ? await getFirstDraft(publish.entityId, session)
+          : undefined
       if (firstDraft) {
         const metricTimeToPublish = /** @type {FormTimelineMetric} */ ({
           formStatus: FormStatus.Live,

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -20,6 +20,7 @@ import { logger } from '~/src/helpers/logging/logger.js'
 import { getJson } from '~/src/lib/fetch.js'
 import { client } from '~/src/mongo.js'
 import { getAuditRecordsOfType } from '~/src/repositories/audit-record-repository.js'
+import { getLanguageFilter } from '~/src/repositories/metrics-repository-helper.js'
 import {
   clearMetricsData,
   deleteFormOverviewMetrics,
@@ -28,7 +29,6 @@ import {
   getDrilldownRecords,
   getFirstDraft,
   getFormTimelineMetricsCursor,
-  getLanguageFilter,
   getMetricTotals,
   getNumberOfFormsInDraft,
   isFirstPublish,
@@ -37,11 +37,11 @@ import {
   updateMetricTotals
 } from '~/src/repositories/metrics-repository.js'
 import {
-  CalculationTypes,
   createFormMap,
   dateFallsInsideTimeslot,
   formatDateOnly,
   getMetricCalcType,
+  handleMetricValue,
   isDraftSubmission,
   isLiveSubmission,
   setTimeOnDate
@@ -392,108 +392,6 @@ export async function collectTimelineMetricsFromAudit(
     ...languageProp
   })
   await saveFormTimelineMetrics('n/a', draftCount, session)
-}
-
-/**
- * @param {FormTimelineMetric} metric
- * @param { Record<string, { count?: number }> | undefined } period
- * @param {string} calculationType
- * @param {boolean} [saveDrilldown]
- */
-export function handleMetricValue(
-  metric,
-  period,
-  calculationType,
-  saveDrilldown
-) {
-  if (calculationType === CalculationTypes.AccumulationWithDrilldown) {
-    updateMetricTotal(metric, period, saveDrilldown)
-  }
-  if (calculationType === CalculationTypes.Accumulation) {
-    updateMetricTotal(metric, period)
-  }
-  if (calculationType === CalculationTypes.Snapshot) {
-    setMetricTotal(metric, period)
-  }
-  if (calculationType === CalculationTypes.Average) {
-    updateMetricAverage(metric, period)
-  }
-}
-
-/**
- * @param {FormTimelineMetric} metric
- * @param { Record<string, { count?: number, details?: FormTimelineMetric[] }> | undefined } period
- * @param {boolean} [drillDown]
- */
-export function updateMetricTotal(metric, period, drillDown) {
-  const metricName = metric.metricName
-  if (
-    !period ||
-    (metric.metricName === FormMetricName.Submissions &&
-      metric.formStatus !== FormStatus.Live)
-  ) {
-    return
-  }
-  if (metricName in period && 'count' in period[metricName]) {
-    const currentTotal = period[metricName].count ?? 0
-    const newTotal = currentTotal + metric.metricValue
-    const detail = drillDown
-      ? {
-          details: [...(period[metricName].details ?? []), mapToMinimal(metric)]
-        }
-      : {}
-    period[metricName] = { count: newTotal, ...detail }
-  } else {
-    const detail = drillDown ? { details: [mapToMinimal(metric)] } : {}
-    period[metricName] = { count: metric.metricValue, ...detail }
-  }
-}
-
-/**
- * Remove unwanted properties (reduces the overall document size)
- * @param {FormTimelineMetric} detail
- */
-function mapToMinimal(detail) {
-  return /** @type {FormTimelineMetric} */ ({
-    formId: detail.formId,
-    metricValue: detail.metricValue,
-    createdAt: detail.createdAt
-  })
-}
-
-/**
- * @param {FormTimelineMetric} metric
- * @param { Record<string, { count?: number }> | undefined } period
- */
-export function setMetricTotal(metric, period) {
-  if (!period) {
-    return
-  }
-  const metricName = metric.metricName
-  period[metricName] = { count: metric.metricValue }
-}
-
-/**
- * @param {FormTimelineMetric} metric
- * @param { Record<string, { count?: number, avgTotal?: number, avgCount?: number }> | undefined } period
- */
-export function updateMetricAverage(metric, period) {
-  const metricName = metric.metricName
-  if (!period) {
-    return
-  }
-  if (
-    metricName in period &&
-    'avgTotal' in period[metricName] &&
-    'avgCount' in period[metricName]
-  ) {
-    const currentAvgTotal = period[metricName].avgTotal ?? 0
-    const currentAvgCount = period[metricName].avgCount ?? 0
-    period[metricName].avgTotal = currentAvgTotal + metric.metricValue
-    period[metricName].avgCount = currentAvgCount + 1
-  } else {
-    period[metricName] = { avgTotal: metric.metricValue, avgCount: 1 }
-  }
 }
 
 /**

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -50,6 +50,7 @@ import {
  * @property {string} [searchText] - text to search within a form name
  * @property {string[]} [status] - array of statuses
  * @property {string[]} [org] - arrays of organisations
+ * @property {string[]} [features] - array of features (such as 'Welsh translation' or 'Email confirmation')
  */
 
 /**

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -15,6 +15,7 @@ import {
 } from 'date-fns'
 
 import { config } from '~/src/config/index.js'
+import { CY } from '~/src/constants.js'
 import { logger } from '~/src/helpers/logging/logger.js'
 import { getJson } from '~/src/lib/fetch.js'
 import { client } from '~/src/mongo.js'
@@ -50,7 +51,7 @@ import {
  * @property {string} [searchText] - text to search within a form name
  * @property {string[]} [status] - array of statuses
  * @property {string[]} [org] - arrays of organisations
- * @property {string[]} [features] - array of features (such as 'Welsh translation' or 'Email confirmation')
+ * @property {string} [language] - optional language used at the point of submission
  */
 
 /**
@@ -123,18 +124,41 @@ export async function collectMetrics(
   }
 
   logger.info('[metrics] getting overview metrics')
-  await collectManagerOverviewMetrics(session)
+  // Collects (stores) overview metrics and returns a list of language-capable forms
+  // for filtering in later steps
+  const languageFormIds = await collectManagerOverviewMetrics(session)
 
   while (formatDateOnly(reportDate) <= formatDateOnly(reportEndDate)) {
     logger.info(
       `[metrics] getting timeline metrics for ${reportDate.toISOString()}`
     )
-    await collectTimelineMetrics(submissionUrl, reportDate, session)
-    await collectTimelineMetricsFromAudit(reportDate, session)
+    // All languages
+    await collectTimelineMetrics(submissionUrl, reportDate, undefined, session)
+    // Welsh-only
+    await collectTimelineMetrics(submissionUrl, reportDate, CY, session)
+
+    // All languages
+    await collectTimelineMetricsFromAudit(
+      reportDate,
+      undefined,
+      undefined,
+      session
+    )
+    // Welsh-only
+    await collectTimelineMetricsFromAudit(
+      reportDate,
+      CY,
+      languageFormIds,
+      session
+    )
+
     reportDate = add(reportDate, { days: 1 })
   }
 
-  const totals = await recalcMetrics(reportEndDate, session)
+  const totals = [
+    await recalcMetrics(reportEndDate, undefined, session),
+    await recalcMetrics(reportEndDate, CY, session)
+  ]
   await updateMetricTotals(reportEndDate, totals, session)
   return {
     success: true,
@@ -153,10 +177,15 @@ export async function collectMetrics(
 export async function collectManagerOverviewMetrics(session) {
   await deleteFormOverviewMetrics(session)
 
+  const languageCapableForms = {
+    draftIds: /** @type {Set<string>} */ (new Set()),
+    liveIds: /** @type {Set<string>} */ (new Set())
+  }
+
   // Batch up requests into pages (say 20 forms at a time) to ensure the
   // API calls to forms-manager never take over 1 second to process (over 1 second response triggers an alert)
   let currentPage = 0
-  let pageInfo = /** @type {{totalItems: number}} */ ({})
+  let pageInfo
   do {
     currentPage++
     pageInfo = await processMetricsBatch(
@@ -164,7 +193,17 @@ export async function collectManagerOverviewMetrics(session) {
       METRICS_FORM_BATCH_SIZE,
       session
     )
+    pageInfo.data.forEach((row) => {
+      if (row.draft?.language) {
+        languageCapableForms.draftIds.add(row.draft.formId)
+      }
+      if (row.live?.language) {
+        languageCapableForms.liveIds.add(row.live.formId)
+      }
+    })
   } while (pageInfo.totalItems > currentPage * METRICS_FORM_BATCH_SIZE)
+
+  return languageCapableForms
 }
 
 /**
@@ -212,16 +251,28 @@ export async function getOverviewMetricsForForms(page, perPage) {
  * Collect timeline metrics
  * @param {string} baseUrl
  * @param {Date} reportingDate
+ * @param { string | undefined } language - optional to restrict records to only that language
  * @param {ClientSession} session
  */
-export async function collectTimelineMetrics(baseUrl, reportingDate, session) {
+export async function collectTimelineMetrics(
+  baseUrl,
+  reportingDate,
+  language,
+  session
+) {
+  const languageParam = language ? `&language=${language}` : ''
   const { body } = await getJson(
-    new URL(`${baseUrl}/report/timeline?date=${reportingDate.toISOString()}`),
+    new URL(
+      `${baseUrl}/report/timeline?date=${reportingDate.toISOString()}${languageParam}`
+    ),
     {}
   )
   const metricsArray = /** @type {{ timeline: FormTimelineMetric[] }} */ (body)
 
   for (const metric of metricsArray.timeline) {
+    if (language) {
+      metric.language = language
+    }
     await saveFormTimelineMetrics(metric.formId, metric, session)
   }
 }
@@ -229,12 +280,22 @@ export async function collectTimelineMetrics(baseUrl, reportingDate, session) {
 /**
  * Collect timeline metrics from audit events
  * @param {Date} reportingDate
+ * @param { string | undefined } language - optional to restrict records to only that language
+ * @param {{ draftIds?: Set<string>, liveIds?: Set<string>} | undefined } languageFormIds - optional list of form ids for restriction
  * @param {ClientSession} session
  */
-export async function collectTimelineMetricsFromAudit(reportingDate, session) {
+export async function collectTimelineMetricsFromAudit(
+  reportingDate,
+  language,
+  languageFormIds,
+  session
+) {
+  const languageProp = language ? { language } : {}
+
   // Read 'forms in draft without a live form' so far from previous day
   let numOfFormsNotLive = await getNumberOfFormsInDraft(
     subDays(reportingDate, 1),
+    language,
     session
   )
 
@@ -242,6 +303,7 @@ export async function collectTimelineMetricsFromAudit(reportingDate, session) {
   const firstCreatedCursor = getAuditRecordsOfType(
     AuditEventMessageType.FORM_CREATED,
     reportingDate,
+    languageFormIds?.draftIds,
     session
   )
   for await (const created of firstCreatedCursor) {
@@ -249,7 +311,8 @@ export async function collectTimelineMetricsFromAudit(reportingDate, session) {
       formStatus: FormStatus.Draft,
       metricName: FormMetricName.NewFormsCreated,
       metricValue: 1,
-      createdAt: created.createdAt
+      createdAt: created.createdAt,
+      ...languageProp
     })
     await saveFormTimelineMetrics(created.entityId, metric, session)
 
@@ -260,12 +323,15 @@ export async function collectTimelineMetricsFromAudit(reportingDate, session) {
   const publishCursor = getAuditRecordsOfType(
     AuditEventMessageType.FORM_LIVE_CREATED_FROM_DRAFT,
     reportingDate,
+    languageFormIds?.draftIds,
     session,
     { createdAt: 1 } // Sort earliest first in case the first publish (and subsequent published) occur on the same day
   )
   for await (const publish of publishCursor) {
     // Check if first publish
-    const firstPublish = await isFirstPublish(publish.entityId, session)
+    const firstPublish = languageFormIds?.liveIds?.has(publish.entityId)
+      ? await isFirstPublish(publish.entityId, session)
+      : undefined
     if (firstPublish) {
       // Time to first publish
       numOfFormsNotLive--
@@ -274,11 +340,14 @@ export async function collectTimelineMetricsFromAudit(reportingDate, session) {
         formStatus: FormStatus.Live,
         metricName: FormMetricName.FormsFirstPublished,
         metricValue: 1,
-        createdAt: publish.createdAt
+        createdAt: publish.createdAt,
+        ...languageProp
       })
       await saveFormTimelineMetrics(publish.entityId, metricPublish, session)
 
-      const firstDraft = await getFirstDraft(publish.entityId, session)
+      const firstDraft = languageFormIds?.draftIds?.has(publish.entityId)
+        ? await getFirstDraft(publish.entityId, session)
+        : undefined
       if (firstDraft) {
         const metricTimeToPublish = /** @type {FormTimelineMetric} */ ({
           formStatus: FormStatus.Live,
@@ -287,7 +356,8 @@ export async function collectTimelineMetricsFromAudit(reportingDate, session) {
             publish.createdAt,
             firstDraft.createdAt
           ),
-          createdAt: publish.createdAt
+          createdAt: publish.createdAt,
+          ...languageProp
         })
         await saveFormTimelineMetrics(
           publish.entityId,
@@ -300,7 +370,8 @@ export async function collectTimelineMetricsFromAudit(reportingDate, session) {
         formStatus: FormStatus.Live,
         metricName: FormMetricName.FormsRePublished,
         metricValue: 1,
-        createdAt: publish.createdAt
+        createdAt: publish.createdAt,
+        ...languageProp
       })
       await saveFormTimelineMetrics(publish.entityId, metricPublish, session)
     }
@@ -310,7 +381,8 @@ export async function collectTimelineMetricsFromAudit(reportingDate, session) {
     metricName: FormMetricName.FormsInDraft,
     metricValue: numOfFormsNotLive,
     formStatus: FormStatus.Draft,
-    createdAt: reportingDate
+    createdAt: reportingDate,
+    ...languageProp
   })
   await saveFormTimelineMetrics('n/a', draftCount, session)
 }
@@ -420,11 +492,12 @@ export function updateMetricAverage(metric, period) {
 /**
  * Update metric totals by summing metrics within given windows
  * @param {Date} reportingDate
+ * @param { string | undefined } language
  * @param {ClientSession} session
  * @param {string} [formId] - supplied if calcs are for a specific form
  * @returns {Promise<FormTotalsMetric>}
  */
-export async function recalcMetrics(reportingDate, session, formId) {
+export async function recalcMetrics(reportingDate, language, session, formId) {
   const reportMorning = startOfDay(reportingDate)
   const sevenDaysAgo = subDays(reportMorning, 7)
   const fourteenDaysAgo = subDays(reportMorning, 14)
@@ -454,10 +527,19 @@ export async function recalcMetrics(reportingDate, session, formId) {
   let earliestDataDate
 
   const metricCursor = formId
-    ? getFormTimelineMetricsCursor(formId, session)
-    : getAllTimelineMetrics(session)
+    ? getFormTimelineMetricsCursor(formId, language, session)
+    : getAllTimelineMetrics(language, session)
 
   for await (const metric of metricCursor) {
+    // FormsInDraft needs special attention since the cursor will return values from 'all' and other languages (e.g. Welsh),
+    // therefore the totals must only use the relevant value for the language (or no language)
+    if (
+      metric.metricName === FormMetricName.FormsInDraft &&
+      language !== metric.language
+    ) {
+      continue
+    }
+
     const metricCalcType = getMetricCalcType(metric)
     if (metric.metricName === FormMetricName.Submissions) {
       // Live submissions
@@ -519,7 +601,11 @@ export async function recalcMetrics(reportingDate, session, formId) {
   totals.republished = Object.fromEntries(maps.formRepublishedMap)
   // Approximate implementation date as fallback if no submissions found
   totals.earliestDate = earliestDataDate ?? new Date('2025-12-01')
+  if (language) {
+    totals.language = language
+  }
   const finalTotals = calcAverages(totals)
+
   return finalTotals
 }
 
@@ -629,7 +715,7 @@ export async function generateReport(filter) {
     const overview = await getAllOverviewMetrics(filter, session).toArray()
 
     // Get summary tiles
-    const totals = await getMetricTotals(session)
+    const totals = await getMetricTotals(filter.language, session)
     // Apply extra columns: submissionsCount, re-published, daysToPublish
     const overviewFull = applyExtraColumns({ overview, totals })
 
@@ -645,20 +731,21 @@ export async function generateReport(filter) {
 /**
  * Generates a report for a single form, based on the stored metrics
  * @param {string} formId
+ * @param { string | undefined } language
  */
-export async function generateReportForForm(formId) {
+export async function generateReportForForm(formId, language) {
   const session = client.startSession()
 
   try {
     const yesterday = sub(new Date(), { days: 1 })
 
-    const totals = await recalcMetrics(yesterday, session, formId)
+    const totals = await recalcMetrics(yesterday, language, session, formId)
 
     // Determine the full date range (from = earliestDate, to = updatedAt)
     // of when submissions have been collected (not just for this for form but
     // across the system), so the user can be shown when the system started
     // storing submissions.
-    const { earliestDate, updatedAt } = await getMetricTotals(session)
+    const { earliestDate, updatedAt } = await getMetricTotals(language, session)
     totals.earliestDate = earliestDate
     totals.updatedAt = updatedAt
 
@@ -674,12 +761,18 @@ export async function generateReportForForm(formId) {
  * Generates a drilldown report (sub-details of a tile)
  * @param {string} period
  * @param {FormMetricName} metricName
+ * @param { string | undefined } language
  */
-export async function generateDrilldownReport(period, metricName) {
+export async function generateDrilldownReport(period, metricName, language) {
   const session = client.startSession()
 
   try {
-    const drilldownRows = await getDrilldownRecords(period, metricName, session)
+    const drilldownRows = await getDrilldownRecords(
+      period,
+      metricName,
+      language,
+      session
+    )
     return {
       drilldownRows
     }

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -329,6 +329,7 @@ describe('runMetricsCollectionJob', () => {
       await collectTimelineMetrics(
         'http://localhost/base-url',
         new Date(),
+        undefined,
         mockSession
       )
       expect(saveFormTimelineMetrics).toHaveBeenCalledTimes(2)
@@ -515,7 +516,11 @@ describe('runMetricsCollectionJob', () => {
       // @ts-expect-error - resolves to an async iterator like FindCursor<FormSubmissionDocument>
       jest.mocked(getAllTimelineMetrics).mockReturnValueOnce(mockAsyncIterator)
 
-      const totals = await recalcMetrics(new Date('2026-01-01'), mockSession)
+      const totals = await recalcMetrics(
+        new Date('2026-01-01'),
+        undefined,
+        mockSession
+      )
 
       expect(totals.last7Days?.NewFormsCreated.details).toHaveLength(3)
       expect(totals.last7Days?.Submissions.details).toHaveLength(4)
@@ -642,7 +647,12 @@ describe('runMetricsCollectionJob', () => {
         // @ts-expect-error - partial mock of record
         .mockResolvedValue({ createdAt: new Date('2026-03-30') })
 
-      await collectTimelineMetricsFromAudit(testDate, mockSession)
+      await collectTimelineMetricsFromAudit(
+        testDate,
+        undefined,
+        undefined,
+        mockSession
+      )
       expect(saveFormTimelineMetrics).toHaveBeenCalledTimes(4)
       expect(saveFormTimelineMetrics).toHaveBeenNthCalledWith(
         1,
@@ -1223,7 +1233,7 @@ describe('runMetricsCollectionJob', () => {
         }
       )
 
-      const res = await generateReportForForm('form-id-1')
+      const res = await generateReportForForm('form-id-1', undefined)
       expect(res).toEqual({
         totals: {
           last7Days: {},
@@ -1273,7 +1283,8 @@ describe('runMetricsCollectionJob', () => {
 
       const res = await generateDrilldownReport(
         'last7Days',
-        FormMetricName.NewFormsCreated
+        FormMetricName.NewFormsCreated,
+        undefined
       )
       expect(res).toEqual({
         drilldownRows: [

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -51,6 +51,29 @@ jest.mock('~/src/mongo.js', () => ({
 }))
 
 /**
+ * @param {AuditRecordInput[]} metricRows
+ */
+function createAsyncIterator(metricRows) {
+  return {
+    [Symbol.asyncIterator]: function* () {
+      for (const metric of metricRows) {
+        yield metric
+      }
+    }
+  }
+}
+
+/**
+ * @param {{ all: AuditRecordInput[], welsh: AuditRecordInput[] }} formRows
+ */
+function createIterators(formRows) {
+  return {
+    all: createAsyncIterator(formRows.all),
+    welsh: createAsyncIterator(formRows.welsh)
+  }
+}
+
+/**
  * @param {FormMetricName} metricName
  * @param {FormStatus} formStatus
  * @param {string} dateStr
@@ -75,64 +98,113 @@ function createTimelineMetric(
   }
 }
 
-const firstCreated = /** @type {AuditRecordInput[]} */ ([
-  {
-    type: 'FORM_CREATED',
-    entityId: 'form-id-1a',
-    createdAt: new Date('2026-03-30')
-  }
-])
-const mockAsyncIteratorFirstCreated = {
-  [Symbol.asyncIterator]: function* () {
-    for (const metric of firstCreated) {
-      yield metric
+const FIRST_CREATED_FORMS = {
+  all: /** @type {AuditRecordInput[]} */ ([
+    {
+      type: 'FORM_CREATED',
+      entityId: 'form-id-1a',
+      createdAt: new Date('2026-03-30')
+    },
+    {
+      type: 'FORM_CREATED',
+      entityId: 'form-id-welsh',
+      createdAt: new Date('2026-04-01')
     }
-  }
-}
-const draftCreatedFromLive = /** @type {AuditRecordInput[]} */ ([
-  {
-    type: 'FORM_CREATED',
-    entityId: 'form-id-1a',
-    createdAt: new Date('2026-03-30')
-  }
-])
-const mockAsyncIteratorDraftCreatedFromLive = {
-  [Symbol.asyncIterator]: function* () {
-    for (const metric of draftCreatedFromLive) {
-      yield metric
+  ]),
+  welsh: /** @type {AuditRecordInput[]} */ ([
+    {
+      type: 'FORM_CREATED',
+      entityId: 'form-id-2a',
+      createdAt: new Date('2026-04-02')
     }
-  }
+  ])
 }
 
-const firstPublished = /** @type {AuditRecordInput[]} */ ([
-  {
-    type: 'FORM_LIVE_CREATED_FROM_DRAFT',
-    entityId: 'form-id-1a',
-    createdAt: new Date('2026-04-08')
-  }
-])
-const mockAsyncIteratorFirstPublished = {
-  [Symbol.asyncIterator]: function* () {
-    for (const metric of firstPublished) {
-      yield metric
+const FIRST_CREATED_ITERATORS = createIterators(FIRST_CREATED_FORMS)
+
+const DRAFT_CREATED_FROM_LIVE_FORMS = {
+  all: /** @type {AuditRecordInput[]} */ ([
+    {
+      type: 'FORM_CREATED',
+      entityId: 'form-id-1a',
+      createdAt: new Date('2026-03-30')
+    },
+    {
+      type: 'FORM_CREATED',
+      entityId: 'form-id-welsh',
+      createdAt: new Date('2026-04-01')
     }
-  }
+  ]),
+  welsh: /** @type {AuditRecordInput[]} */ ([
+    {
+      type: 'FORM_CREATED',
+      entityId: 'form-id-welsh',
+      createdAt: new Date('2026-04-01')
+    }
+  ])
 }
 
-const rePublished = /** @type {AuditRecordInput[]} */ ([
-  {
-    type: 'FORM_LIVE_CREATED_FROM_DRAFT',
-    entityId: 'form-id-1a',
-    createdAt: new Date('2026-04-14')
-  }
-])
-const mockAsyncIteratorRePublished = {
-  [Symbol.asyncIterator]: function* () {
-    for (const metric of rePublished) {
-      yield metric
+const DRAFT_CREATED_FROM_LIVE_ITERATORS = createIterators(
+  DRAFT_CREATED_FROM_LIVE_FORMS
+)
+
+const FIRST_PUBLISHED_FORMS = {
+  all: /** @type {AuditRecordInput[]} */ ([
+    {
+      type: 'FORM_LIVE_CREATED_FROM_DRAFT',
+      entityId: 'form-id-1a',
+      createdAt: new Date('2026-04-08')
+    },
+    {
+      type: 'FORM_LIVE_CREATED_FROM_DRAFT',
+      entityId: 'form-id-welsh',
+      createdAt: new Date('2026-04-14')
     }
-  }
+  ]),
+  welsh: /** @type {AuditRecordInput[]} */ ([
+    {
+      type: 'FORM_LIVE_CREATED_FROM_DRAFT',
+      entityId: 'form-id-welsh',
+      createdAt: new Date('2026-04-14')
+    }
+  ])
 }
+
+const FIRST_PUBLISHED_ITERATORS = createIterators(FIRST_PUBLISHED_FORMS)
+
+const REPUBLISHED_FORMS = {
+  all: /** @type {AuditRecordInput[]} */ ([
+    {
+      type: 'FORM_LIVE_CREATED_FROM_DRAFT',
+      entityId: 'form-id-1a',
+      createdAt: new Date('2026-04-14')
+    },
+    {
+      type: 'FORM_LIVE_CREATED_FROM_DRAFT',
+      entityId: 'form-id-welsh',
+      createdAt: new Date('2026-04-18')
+    },
+    {
+      type: 'FORM_LIVE_CREATED_FROM_DRAFT',
+      entityId: 'form-id-welsh',
+      createdAt: new Date('2026-04-19')
+    }
+  ]),
+  welsh: /** @type {AuditRecordInput[]} */ ([
+    {
+      type: 'FORM_LIVE_CREATED_FROM_DRAFT',
+      entityId: 'form-id-welsh',
+      createdAt: new Date('2026-04-18')
+    },
+    {
+      type: 'FORM_LIVE_CREATED_FROM_DRAFT',
+      entityId: 'form-id-welsh',
+      createdAt: new Date('2026-04-19')
+    }
+  ])
+}
+
+const REPUBLISHED_ITERATORS = createIterators(REPUBLISHED_FORMS)
 
 describe('runMetricsCollectionJob', () => {
   /** @type {any} */
@@ -641,11 +713,11 @@ describe('runMetricsCollectionJob', () => {
       jest
         .mocked(getAuditRecordsOfType)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        .mockReturnValueOnce(FIRST_CREATED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+        .mockReturnValueOnce(FIRST_PUBLISHED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorRePublished)
+        .mockReturnValueOnce(REPUBLISHED_ITERATORS.all)
 
       jest
         .mocked(isFirstPublish)
@@ -662,7 +734,7 @@ describe('runMetricsCollectionJob', () => {
         undefined,
         mockSession
       )
-      expect(saveFormTimelineMetrics).toHaveBeenCalledTimes(4)
+      expect(saveFormTimelineMetrics).toHaveBeenCalledTimes(6)
       expect(saveFormTimelineMetrics).toHaveBeenNthCalledWith(
         1,
         'form-id-1a',
@@ -676,11 +748,11 @@ describe('runMetricsCollectionJob', () => {
       )
       expect(saveFormTimelineMetrics).toHaveBeenNthCalledWith(
         2,
-        'form-id-1a',
+        'form-id-welsh',
         {
-          createdAt: new Date('2026-04-08T00:00:00.000Z'),
-          formStatus: 'live',
-          metricName: 'FormsFirstPublished',
+          createdAt: new Date('2026-04-01T00:00:00.000Z'),
+          formStatus: 'draft',
+          metricName: 'NewFormsCreated',
           metricValue: 1
         },
         expect.anything()
@@ -691,19 +763,41 @@ describe('runMetricsCollectionJob', () => {
         {
           createdAt: new Date('2026-04-08T00:00:00.000Z'),
           formStatus: 'live',
+          metricName: 'FormsFirstPublished',
+          metricValue: 1
+        },
+        expect.anything()
+      )
+      expect(saveFormTimelineMetrics).toHaveBeenNthCalledWith(
+        4,
+        'form-id-1a',
+        {
+          createdAt: new Date('2026-04-08T00:00:00.000Z'),
+          formStatus: 'live',
           metricName: 'TimeToPublish',
           metricValue: 9
         },
         expect.anything()
       )
       expect(saveFormTimelineMetrics).toHaveBeenNthCalledWith(
-        4,
+        5,
+        'form-id-welsh',
+        {
+          createdAt: new Date('2026-04-14T00:00:00.000Z'),
+          formStatus: 'live',
+          metricName: 'FormsRePublished',
+          metricValue: 1
+        },
+        expect.anything()
+      )
+      expect(saveFormTimelineMetrics).toHaveBeenNthCalledWith(
+        6,
         'n/a',
         {
           createdAt: new Date('2026-05-01T00:00:00.000Z'),
           formStatus: 'draft',
           metricName: 'FormsInDraft',
-          metricValue: 17
+          metricValue: 18
         },
         expect.anything()
       )
@@ -992,17 +1086,17 @@ describe('runMetricsCollectionJob', () => {
       jest
         .mocked(getAuditRecordsOfType)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        .mockReturnValueOnce(FIRST_CREATED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        .mockReturnValueOnce(DRAFT_CREATED_FROM_LIVE_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+        .mockReturnValueOnce(FIRST_PUBLISHED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        .mockReturnValueOnce(FIRST_CREATED_ITERATORS.welsh)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        .mockReturnValueOnce(DRAFT_CREATED_FROM_LIVE_ITERATORS.welsh)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+        .mockReturnValueOnce(FIRST_PUBLISHED_ITERATORS.welsh)
 
       const blankSet = /** @type {AuditRecordInput[]} */ ([])
       const mockAsyncIteratorBlankSet = {
@@ -1043,6 +1137,37 @@ describe('runMetricsCollectionJob', () => {
       expect(calls[2][0].href).toBe(
         'http://localhost:3002/report/timeline?date=2026-05-12T15:56:04.364Z&language=cy'
       )
+      expect(getAuditRecordsOfType).toHaveBeenCalledTimes(4)
+      expect(getAuditRecordsOfType).toHaveBeenNthCalledWith(
+        1,
+        'FORM_CREATED',
+        new Date('2026-05-12T15:56:04.364Z'),
+        undefined,
+        expect.anything()
+      )
+      expect(getAuditRecordsOfType).toHaveBeenNthCalledWith(
+        2,
+        'FORM_LIVE_CREATED_FROM_DRAFT',
+        new Date('2026-05-12T15:56:04.364Z'),
+        undefined,
+        expect.anything(),
+        { createdAt: 1 } // Overrides sort option
+      )
+      expect(getAuditRecordsOfType).toHaveBeenNthCalledWith(
+        3,
+        'FORM_CREATED',
+        new Date('2026-05-12T15:56:04.364Z'),
+        expect.anything(),
+        expect.anything()
+      )
+      expect(getAuditRecordsOfType).toHaveBeenNthCalledWith(
+        4,
+        'FORM_LIVE_CREATED_FROM_DRAFT',
+        new Date('2026-05-12T15:56:04.364Z'),
+        expect.anything(),
+        expect.anything(),
+        { createdAt: 1 } // Overrides sort option
+      )
     })
 
     it('should loop if multiple days to report', async () => {
@@ -1074,29 +1199,29 @@ describe('runMetricsCollectionJob', () => {
       jest
         .mocked(getAuditRecordsOfType)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        .mockReturnValueOnce(FIRST_CREATED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        .mockReturnValueOnce(DRAFT_CREATED_FROM_LIVE_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+        .mockReturnValueOnce(FIRST_PUBLISHED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        .mockReturnValueOnce(FIRST_CREATED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        .mockReturnValueOnce(DRAFT_CREATED_FROM_LIVE_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+        .mockReturnValueOnce(FIRST_PUBLISHED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        .mockReturnValueOnce(FIRST_CREATED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        .mockReturnValueOnce(DRAFT_CREATED_FROM_LIVE_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+        .mockReturnValueOnce(FIRST_PUBLISHED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        .mockReturnValueOnce(FIRST_CREATED_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        .mockReturnValueOnce(DRAFT_CREATED_FROM_LIVE_ITERATORS.all)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
-        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
+        .mockReturnValueOnce(FIRST_PUBLISHED_ITERATORS.all)
 
       const blankSet = /** @type {AuditRecordInput[]} */ ([])
       const mockAsyncIteratorBlankSet = {
@@ -1243,6 +1368,13 @@ describe('runMetricsCollectionJob', () => {
           '2024-04-20',
           1,
           'form-id-1'
+        ),
+        createTimelineMetric(
+          FormMetricName.NewFormsCreated,
+          FormStatus.Draft,
+          '2024-04-23',
+          1,
+          'form-id-welsh'
         )
       ]
 
@@ -1280,11 +1412,16 @@ describe('runMetricsCollectionJob', () => {
           prevYear: {},
           allTime: {
             [FormMetricName.NewFormsCreated]: {
-              count: 1,
+              count: 2,
               details: [
                 {
                   createdAt: new Date('2024-04-20T00:00:00.000Z'),
                   formId: 'form-id-1',
+                  metricValue: 1
+                },
+                {
+                  createdAt: new Date('2024-04-23T00:00:00.000Z'),
+                  formId: 'form-id-welsh',
                   metricValue: 1
                 }
               ]

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -20,6 +20,11 @@ import {
   saveFormOverviewMetrics,
   saveFormTimelineMetrics
 } from '~/src/repositories/metrics-repository.js'
+import {
+  setMetricTotal,
+  updateMetricAverage,
+  updateMetricTotal
+} from '~/src/service/metrics-helper.js'
 import { runMetricsCollectionJob } from '~/src/service/metrics-job.js'
 import {
   applyExtraColumns,
@@ -32,10 +37,7 @@ import {
   generateReport,
   generateReportForForm,
   getOverviewMetricsForForms,
-  recalcMetrics,
-  setMetricTotal,
-  updateMetricAverage,
-  updateMetricTotal
+  recalcMetrics
 } from '~/src/service/metrics.js'
 
 jest.mock('~/src/lib/fetch.js')
@@ -359,6 +361,41 @@ describe('runMetricsCollectionJob', () => {
 
       await collectManagerOverviewMetrics(mockSession)
       expect(saveFormOverviewMetrics).toHaveBeenCalledTimes(2)
+    })
+
+    it('should save each metric and add to language capable forms (if form has language set)', async () => {
+      jest.mocked(getJson).mockResolvedValueOnce({
+        response: {},
+        body: {
+          data: [
+            {
+              draft: {
+                draftProperty: 123,
+                language: 'cy',
+                formId: 'form-1-welsh'
+              },
+              live: {
+                liveProperty: 123,
+                language: 'cy',
+                formId: 'form-1-welsh'
+              }
+            },
+            {
+              draft: {
+                draftProperty: 123,
+                language: 'cy',
+                formId: 'form-2-welsh'
+              },
+              live: {}
+            }
+          ],
+          totalItems: 2
+        }
+      })
+
+      const res = await collectManagerOverviewMetrics(mockSession)
+      expect(Array.from(res.draftIds)).toEqual(['form-1-welsh', 'form-2-welsh'])
+      expect(Array.from(res.liveIds)).toEqual(['form-1-welsh'])
     })
 
     it('should save each metric as multiple batches when more than 20 in size', async () => {

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -215,7 +215,7 @@ describe('runMetricsCollectionJob', () => {
     jest.mocked(getAllTimelineMetrics).mockReturnValueOnce(mockAsyncIterator)
 
     await runMetricsCollectionJob()
-    expect(getJson).toHaveBeenCalledTimes(2)
+    expect(getJson).toHaveBeenCalledTimes(3)
     expect(getJson).toHaveBeenNthCalledWith(
       1,
       new URL('http://localhost:3001/report/overview?page=1&perPage=20'),
@@ -225,6 +225,15 @@ describe('runMetricsCollectionJob', () => {
       2,
       new URL(
         'http://localhost:3002/report/timeline?date=' + twoDaysAgo.toISOString()
+      ),
+      {}
+    )
+    expect(getJson).toHaveBeenNthCalledWith(
+      3,
+      new URL(
+        'http://localhost:3002/report/timeline?date=' +
+          twoDaysAgo.toISOString() +
+          '&language=cy'
       ),
       {}
     )
@@ -978,9 +987,16 @@ describe('runMetricsCollectionJob', () => {
           body: { data: [], totalItems: 0 }
         })
         .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
 
       jest
         .mocked(getAuditRecordsOfType)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorDraftCreatedFromLive)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorFirstPublished)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
         .mockReturnValueOnce(mockAsyncIteratorFirstCreated)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
@@ -1001,6 +1017,8 @@ describe('runMetricsCollectionJob', () => {
         .mocked(getAllTimelineMetrics)
         // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
         .mockReturnValueOnce(mockAsyncIteratorBlankSet)
+        // @ts-expect-error - resolves to an async iterator like FindCursor<AuditRecordInput>
+        .mockReturnValueOnce(mockAsyncIteratorBlankSet)
 
       const res = await collectMetrics(
         currentRunDate,
@@ -1014,13 +1032,16 @@ describe('runMetricsCollectionJob', () => {
         endDate: new Date('2026-05-12T03:00:00.000Z'),
         processMoreBatches: false
       })
-      expect(getJson).toHaveBeenCalledTimes(2)
+      expect(getJson).toHaveBeenCalledTimes(3)
       const calls = jest.mocked(getJson).mock.calls
       expect(calls[0][0].href).toBe(
         'http://localhost:3001/report/overview?page=1&perPage=20'
       )
       expect(calls[1][0].href).toBe(
         'http://localhost:3002/report/timeline?date=2026-05-12T15:56:04.364Z'
+      )
+      expect(calls[2][0].href).toBe(
+        'http://localhost:3002/report/timeline?date=2026-05-12T15:56:04.364Z&language=cy'
       )
     })
 
@@ -1041,6 +1062,10 @@ describe('runMetricsCollectionJob', () => {
           response: {},
           body: { data: [] }
         })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
         .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
         .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
         .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
@@ -1106,7 +1131,7 @@ describe('runMetricsCollectionJob', () => {
         endDate: new Date('2026-03-09T03:00:00.000Z'),
         processMoreBatches: false
       })
-      expect(getJson).toHaveBeenCalledTimes(4)
+      expect(getJson).toHaveBeenCalledTimes(7)
       const calls = jest.mocked(getJson).mock.calls
       expect(calls[0][0].href).toBe(
         'http://localhost:3001/report/overview?page=1&perPage=20'
@@ -1115,10 +1140,19 @@ describe('runMetricsCollectionJob', () => {
         'http://localhost:3002/report/timeline?date=2026-03-07T04:00:00.000Z'
       )
       expect(calls[2][0].href).toBe(
-        'http://localhost:3002/report/timeline?date=2026-03-08T04:00:00.000Z'
+        'http://localhost:3002/report/timeline?date=2026-03-07T04:00:00.000Z&language=cy'
       )
       expect(calls[3][0].href).toBe(
+        'http://localhost:3002/report/timeline?date=2026-03-08T04:00:00.000Z'
+      )
+      expect(calls[4][0].href).toBe(
+        'http://localhost:3002/report/timeline?date=2026-03-08T04:00:00.000Z&language=cy'
+      )
+      expect(calls[5][0].href).toBe(
         'http://localhost:3002/report/timeline?date=2026-03-09T04:00:00.000Z'
+      )
+      expect(calls[6][0].href).toBe(
+        'http://localhost:3002/report/timeline?date=2026-03-09T04:00:00.000Z&language=cy'
       )
     })
 
@@ -1143,6 +1177,8 @@ describe('runMetricsCollectionJob', () => {
       jest
         .mocked(getJson)
         .mockResolvedValueOnce({ response: {}, body: { data: [] } })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
+        .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
         .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
         .mockResolvedValueOnce({ response: {}, body: { timeline: [] } })
 


### PR DESCRIPTION
Handle welsh metrics as separate metrics:
- still collates the 'all forms' metrics
- now can generate 'forms with welsh translation' metrics independently of 'all forms'

Metrics data structures can have an optional `language` property - which is set to 'cy' for Welsh.
Metrics data that is for 'all forms' does not have this `language` property added.

Requires a model bump from this PR https://github.com/DEFRA/forms-designer/pull/1538

