### PR TITLE
fix/df-1257: Corrected filtering of calcs

### DIFF
--- a/src/repositories/metrics-repository-helper.js
+++ b/src/repositories/metrics-repository-helper.js
@@ -1,3 +1,7 @@
+import { FormMetricName, FormMetricType } from '@defra/forms-model'
+
+import { getErrorMessage } from '~/src/helpers/error-message.js'
+import { logger } from '~/src/helpers/logging/logger.js'
 import { METRICS_COLLECTION_NAME, db } from '~/src/mongo.js'
 
 /**
@@ -27,7 +31,72 @@ export function getMetricCollection() {
 }
 
 /**
- * @import { Collection } from 'mongodb'
+ * Determines if any other publish events exist for this form
+ * @param {string} formId
+ * @param { string | undefined } language
+ * @param {ClientSession} session
+ * @returns {Promise<boolean>}
+ */
+export async function isFirstPublish(formId, language, session) {
+  const coll = getMetricCollection()
+
+  try {
+    const firstPublished = await coll.findOne(
+      {
+        type: FormMetricType.TimelineMetric,
+        metricName: FormMetricName.FormsFirstPublished,
+        formId,
+        ...getLanguageFilter(language)
+      },
+      { session }
+    )
+    return firstPublished === null
+  } catch (err) {
+    logger.error(
+      err,
+      `Failed to read timeline isFirstPublish for form id ${formId} - ${getErrorMessage(err)}`
+    )
+    throw err
+  }
+}
+
+/**
+ * Gets the earliest 'draft created' record of a form
+ * @param {string} formId
+ * @param { string | undefined } language
+ * @param {ClientSession} session
+ * @returns {Promise< WithId<FormTimelineMetric> | undefined >}
+ */
+export async function getFirstDraft(formId, language, session) {
+  const coll = getMetricCollection()
+
+  try {
+    const drafts = /** @type {WithId<FormTimelineMetric>[]} */ (
+      await coll
+        .find(
+          {
+            type: FormMetricType.TimelineMetric,
+            metricName: FormMetricName.NewFormsCreated,
+            formId,
+            ...getLanguageFilter(language)
+          },
+          { session }
+        )
+        .sort({ createdAt: 1 })
+        .toArray()
+    )
+    return drafts.length > 0 ? drafts[0] : undefined
+  } catch (err) {
+    logger.error(
+      err,
+      `Failed to read timeline getFirstDraft for form id ${formId} - ${getErrorMessage(err)}`
+    )
+    throw err
+  }
+}
+
+/**
+ * @import { ClientSession, Collection, WithId } from 'mongodb'
  * @import { FormOverviewMetric, FormTimelineMetric, FormTotalsMetric, FormDrilldownMetric } from '@defra/forms-model'
  * @import { FormMetricControl } from '~/src/service/metrics.js'
  */

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -434,71 +434,6 @@ export async function saveDrilldownRecords(
 }
 
 /**
- * Determines if any other publish events exist for this form
- * @param {string} formId
- * @param { string | undefined } language
- * @param {ClientSession} session
- * @returns {Promise<boolean>}
- */
-export async function isFirstPublish(formId, language, session) {
-  const coll = getMetricCollection()
-
-  try {
-    const firstPublished = await coll.findOne(
-      {
-        type: FormMetricType.TimelineMetric,
-        metricName: FormMetricName.FormsFirstPublished,
-        formId,
-        ...getLanguageFilter(language)
-      },
-      { session }
-    )
-    return firstPublished === null
-  } catch (err) {
-    logger.error(
-      err,
-      `Failed to read timeline isFirstPublish for form id ${formId} - ${getErrorMessage(err)}`
-    )
-    throw err
-  }
-}
-
-/**
- * Gets the earliest 'draft created' record of a form
- * @param {string} formId
- * @param { string | undefined } language
- * @param {ClientSession} session
- * @returns {Promise< WithId<FormTimelineMetric> | undefined >}
- */
-export async function getFirstDraft(formId, language, session) {
-  const coll = getMetricCollection()
-
-  try {
-    const drafts = /** @type {WithId<FormTimelineMetric>[]} */ (
-      await coll
-        .find(
-          {
-            type: FormMetricType.TimelineMetric,
-            metricName: FormMetricName.NewFormsCreated,
-            formId,
-            ...getLanguageFilter(language)
-          },
-          { session }
-        )
-        .sort({ createdAt: 1 })
-        .toArray()
-    )
-    return drafts.length > 0 ? drafts[0] : undefined
-  } catch (err) {
-    logger.error(
-      err,
-      `Failed to read timeline getFirstDraft for form id ${formId} - ${getErrorMessage(err)}`
-    )
-    throw err
-  }
-}
-
-/**
  * Gets the 'forms in draft' metric for the specified date and returns the value
  * @param {Date} reportingDate
  * @param { string | undefined } language
@@ -686,7 +621,7 @@ export async function clearMetricsData(session) {
 }
 
 /**
- * @import { ClientSession, Collection, FindCursor, WithId } from 'mongodb'
+ * @import { ClientSession, FindCursor, WithId } from 'mongodb'
  * @import { FormOverviewMetric, FormTimelineMetric, FormTotalsMetric, FormDrilldownMetric } from '@defra/forms-model'
  * @import { FilterCriteria, FormMetricControl } from '~/src/service/metrics.js'
  */

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -129,7 +129,7 @@ export function getFormTimelineMetricsCursor(formId, language, session) {
             {
               formId,
               type: FormMetricType.TimelineMetric,
-              ...getLanguageFilter(language)
+              ...getLanguageNoPropertyFilter(language)
             },
             { session }
           )
@@ -219,7 +219,7 @@ export function getAllTimelineMetrics(language, session) {
         .find(
           {
             type: FormMetricType.TimelineMetric,
-            ...getLanguageFilter(language)
+            ...getLanguageNoPropertyFilter(language)
           },
           { session }
         )
@@ -273,7 +273,10 @@ export function getMetricTotals(language, session) {
   try {
     return /** @type {Promise<WithId<FormTotalsMetric>>} */ (
       coll.findOne(
-        { type: FormMetricType.TotalsMetric, ...getLanguageFilter(language) },
+        {
+          type: FormMetricType.TotalsMetric,
+          ...getLanguageNoPropertyFilter(language)
+        },
         { session }
       )
     )
@@ -306,7 +309,7 @@ export async function getDrilldownRecords(
             type: FormMetricType.DrilldownMetric,
             periodName,
             metricName,
-            ...getLanguageFilter(language)
+            ...getLanguageNoPropertyFilter(language)
           },
           { session }
         )
@@ -433,10 +436,11 @@ export async function saveDrilldownRecords(
 /**
  * Determines if any other publish events exist for this form
  * @param {string} formId
+ * @param { string | undefined } language
  * @param {ClientSession} session
  * @returns {Promise<boolean>}
  */
-export async function isFirstPublish(formId, session) {
+export async function isFirstPublish(formId, language, session) {
   const coll = getMetricCollection()
 
   try {
@@ -444,7 +448,8 @@ export async function isFirstPublish(formId, session) {
       {
         type: FormMetricType.TimelineMetric,
         metricName: FormMetricName.FormsFirstPublished,
-        formId
+        formId,
+        ...getLanguageFilter(language)
       },
       { session }
     )
@@ -461,10 +466,11 @@ export async function isFirstPublish(formId, session) {
 /**
  * Gets the earliest 'draft created' record of a form
  * @param {string} formId
+ * @param { string | undefined } language
  * @param {ClientSession} session
  * @returns {Promise< WithId<FormTimelineMetric> | undefined >}
  */
-export async function getFirstDraft(formId, session) {
+export async function getFirstDraft(formId, language, session) {
   const coll = getMetricCollection()
 
   try {
@@ -474,7 +480,8 @@ export async function getFirstDraft(formId, session) {
           {
             type: FormMetricType.TimelineMetric,
             metricName: FormMetricName.NewFormsCreated,
-            formId
+            formId,
+            ...getLanguageFilter(language)
           },
           { session }
         )

--- a/src/repositories/metrics-repository.test.js
+++ b/src/repositories/metrics-repository.test.js
@@ -514,7 +514,7 @@ describe('metrics-repository', () => {
   describe('isFirstPublish', () => {
     it('should return true if one or fewer records', async () => {
       mockCollection.findOne.mockReturnValueOnce(null)
-      const res = await isFirstPublish('form-id', mockSession)
+      const res = await isFirstPublish('form-id', undefined, mockSession)
       expect(res).toBe(true)
       expect(mockCollection.findOne).toHaveBeenCalledWith(
         {
@@ -528,7 +528,7 @@ describe('metrics-repository', () => {
 
     it('should return false if one or more records', async () => {
       mockCollection.findOne.mockReturnValueOnce({})
-      const res = await isFirstPublish('form-id', mockSession)
+      const res = await isFirstPublish('form-id', undefined, mockSession)
       expect(res).toBe(false)
       expect(mockCollection.findOne).toHaveBeenCalledWith(
         {
@@ -545,7 +545,7 @@ describe('metrics-repository', () => {
         throw new Error('bad db call')
       })
       await expect(() =>
-        isFirstPublish('form-id', mockSession)
+        isFirstPublish('form-id', undefined, mockSession)
       ).rejects.toThrow('bad db call')
     })
   })
@@ -557,7 +557,7 @@ describe('metrics-repository', () => {
           return { toArray: () => [{ draft1: 123 }, { draft2: 456 }] }
         })
       })
-      const res = await getFirstDraft('form-id', mockSession)
+      const res = await getFirstDraft('form-id', undefined, mockSession)
       expect(res).toEqual({ draft1: 123 })
       expect(mockCollection.find).toHaveBeenCalledWith(
         {
@@ -575,7 +575,7 @@ describe('metrics-repository', () => {
           return { toArray: () => [] }
         })
       })
-      const res = await getFirstDraft('form-id', mockSession)
+      const res = await getFirstDraft('form-id', undefined, mockSession)
       expect(res).toBeUndefined()
       expect(mockCollection.find).toHaveBeenCalledWith(
         {
@@ -591,9 +591,9 @@ describe('metrics-repository', () => {
       mockCollection.find.mockImplementationOnce(() => {
         throw new Error('bad db call')
       })
-      await expect(() => getFirstDraft('form-id', mockSession)).rejects.toThrow(
-        'bad db call'
-      )
+      await expect(() =>
+        getFirstDraft('form-id', undefined, mockSession)
+      ).rejects.toThrow('bad db call')
     })
   })
 
@@ -613,7 +613,10 @@ describe('metrics-repository', () => {
         {
           type: FormMetricType.DrilldownMetric,
           metricName: FormMetricName.NewFormsCreated,
-          periodName: 'last7Days'
+          periodName: 'last7Days',
+          language: {
+            $exists: false
+          }
         },
         { session: {} }
       )

--- a/src/repositories/metrics-repository.test.js
+++ b/src/repositories/metrics-repository.test.js
@@ -3,8 +3,10 @@ import { FormMetricName, FormMetricType, FormStatus } from '@defra/forms-model'
 import { buildMockCollection } from '~/src/api/forms/__stubs__/mongo.js'
 import { db } from '~/src/mongo.js'
 import {
+  getFirstDraft,
   getLanguageFilter,
-  getLanguageNoPropertyFilter
+  getLanguageNoPropertyFilter,
+  isFirstPublish
 } from '~/src/repositories/metrics-repository-helper.js'
 import {
   clearMetricsData,
@@ -12,13 +14,11 @@ import {
   getAllOverviewMetrics,
   getAllTimelineMetrics,
   getDrilldownRecords,
-  getFirstDraft,
   getFormOverviewMetrics,
   getFormTimelineMetrics,
   getMetricTotals,
   getNumberOfFormsInDraft,
   grabLock,
-  isFirstPublish,
   releaseLock,
   saveDrilldown,
   saveDrilldownRecords,

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -336,7 +336,7 @@ export async function collectTimelineMetricsFromAudit(
     // Check if first publish
     const firstPublish =
       !languageFormIds || languageFormIds.liveIds?.has(publish.entityId)
-        ? await isFirstPublish(publish.entityId, session)
+        ? await isFirstPublish(publish.entityId, language, session)
         : undefined
     if (firstPublish) {
       // Time to first publish
@@ -353,7 +353,7 @@ export async function collectTimelineMetricsFromAudit(
 
       const firstDraft =
         !languageFormIds || languageFormIds.draftIds?.has(publish.entityId)
-          ? await getFirstDraft(publish.entityId, session)
+          ? await getFirstDraft(publish.entityId, language, session)
           : undefined
       if (firstDraft) {
         const metricTimeToPublish = /** @type {FormTimelineMetric} */ ({

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -20,18 +20,20 @@ import { logger } from '~/src/helpers/logging/logger.js'
 import { getJson } from '~/src/lib/fetch.js'
 import { client } from '~/src/mongo.js'
 import { getAuditRecordsOfType } from '~/src/repositories/audit-record-repository.js'
-import { getLanguageFilter } from '~/src/repositories/metrics-repository-helper.js'
+import {
+  getFirstDraft,
+  getLanguageFilter,
+  isFirstPublish
+} from '~/src/repositories/metrics-repository-helper.js'
 import {
   clearMetricsData,
   deleteFormOverviewMetrics,
   getAllOverviewMetrics,
   getAllTimelineMetrics,
   getDrilldownRecords,
-  getFirstDraft,
   getFormTimelineMetricsCursor,
   getMetricTotals,
   getNumberOfFormsInDraft,
-  isFirstPublish,
   saveFormOverviewMetrics,
   saveFormTimelineMetrics,
   updateMetricTotals

--- a/src/service/metrics.test.js
+++ b/src/service/metrics.test.js
@@ -6,16 +6,18 @@ import { getJson } from '~/src/lib/fetch.js'
 import { client } from '~/src/mongo.js'
 import { getAuditRecordsOfType } from '~/src/repositories/audit-record-repository.js'
 import {
+  getFirstDraft,
+  isFirstPublish
+} from '~/src/repositories/metrics-repository-helper.js'
+import {
   clearMetricsData,
   getAllOverviewMetrics,
   getAllTimelineMetrics,
   getDrilldownRecords,
-  getFirstDraft,
   getFormTimelineMetricsCursor,
   getMetricTotals,
   getNumberOfFormsInDraft,
   grabLock,
-  isFirstPublish,
   releaseLock,
   saveFormOverviewMetrics,
   saveFormTimelineMetrics
@@ -42,6 +44,7 @@ import {
 
 jest.mock('~/src/lib/fetch.js')
 jest.mock('~/src/repositories/metrics-repository.js')
+jest.mock('~/src/repositories/metrics-repository-helper.js')
 jest.mock('~/src/repositories/audit-record-repository.js')
 
 jest.mock('~/src/mongo.js', () => ({


### PR DESCRIPTION
An overcount for 'all forms' was occurring where the Welsh forms were being included twice. This was because records with no language were being added to records with `language: 'cy'` rather than omitting any language-specific records in the counts.

Includes restructuring since Sonar complained `metrics-repository.js` was 502 lines (2 lines more than the allowed).