### PR TITLE
feat/df-1149: Returns monthly submission metrics per form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "convict": "^6.2.5",
         "convict-format-with-validator": "6.2.0",
         "date-fns": "^4.2.1",
+        "date-fns-tz": "^3.2.0",
         "dotenv": "^17.3.1",
         "hapi-pino": "^12.1.0",
         "hapi-pulse": "3.0.1",
@@ -6210,6 +6211,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/dateformat": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "convict": "^6.2.5",
     "convict-format-with-validator": "6.2.0",
     "date-fns": "^4.2.1",
+    "date-fns-tz": "^3.2.0",
     "dotenv": "^17.3.1",
     "hapi-pino": "^12.1.0",
     "hapi-pulse": "3.0.1",

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -206,12 +206,14 @@ export function getAllOverviewMetrics(filter, session) {
 
 /**
  * Get all timeline metrics
- * @param { string | undefined } language
+ * @param { Filter<WithId<FormTimelineMetric>> | undefined } filter
  * @param {ClientSession} session
  * @returns {FindCursor<WithId<FormTimelineMetric>>}
  */
-export function getAllTimelineMetrics(language, session) {
-  const coll = getMetricCollection()
+export function getAllTimelineMetrics(filter, session) {
+  const coll = /** @type {Collection<FormTimelineMetric>} */ (
+    getMetricCollection()
+  )
 
   try {
     const cursor = /** @type {FindCursor<WithId<FormTimelineMetric>>} */ (
@@ -219,7 +221,7 @@ export function getAllTimelineMetrics(language, session) {
         .find(
           {
             type: FormMetricType.TimelineMetric,
-            ...getLanguageNoPropertyFilter(language)
+            ...(filter ?? {})
           },
           { session }
         )
@@ -621,7 +623,7 @@ export async function clearMetricsData(session) {
 }
 
 /**
- * @import { ClientSession, FindCursor, WithId } from 'mongodb'
+ * @import { ClientSession, Collection, Filter, FindCursor, WithId } from 'mongodb'
  * @import { FormOverviewMetric, FormTimelineMetric, FormTotalsMetric, FormDrilldownMetric } from '@defra/forms-model'
  * @import { FilterCriteria, FormMetricControl } from '~/src/service/metrics.js'
  */

--- a/src/repositories/metrics-repository.js
+++ b/src/repositories/metrics-repository.js
@@ -221,7 +221,7 @@ export function getAllTimelineMetrics(filter, session) {
         .find(
           {
             type: FormMetricType.TimelineMetric,
-            ...(filter ?? {})
+            ...filter
           },
           { session }
         )

--- a/src/routes/report.js
+++ b/src/routes/report.js
@@ -97,7 +97,12 @@ export default [
       return h.response(metrics).code(HTTP_OK)
     },
     options: {
-      auth: false
+      auth: false,
+      validate: {
+        query: Joi.object({
+          earliestDate: Joi.date().optional()
+        })
+      }
     }
   }),
 

--- a/src/routes/report.js
+++ b/src/routes/report.js
@@ -3,7 +3,9 @@ import Joi from 'joi'
 
 import { WELSH } from '~/src/constants.js'
 import { runMetricsCollectionJob } from '~/src/service/metrics-job.js'
+import { generateSubmissionsReport } from '~/src/service/metrics-submissions.js'
 import {
+  EARLIEST_REPORT_DATE_AS_STRING,
   clearMetricsDatabase,
   generateDrilldownReport,
   generateReport,
@@ -77,6 +79,25 @@ export default [
         params: paramSchema,
         query: querySchema
       }
+    }
+  }),
+
+  /**
+   * @satisfies {ServerRoute< { Query: { earliestDate?: Date } }>}
+   */
+  ({
+    method: 'GET',
+    path: '/report-submissions',
+    async handler(request, h) {
+      const { earliestDate } = request.query
+      const metrics = await generateSubmissionsReport(
+        earliestDate ?? new Date(EARLIEST_REPORT_DATE_AS_STRING)
+      )
+
+      return h.response(metrics).code(HTTP_OK)
+    },
+    options: {
+      auth: false
     }
   }),
 

--- a/src/routes/report.test.js
+++ b/src/routes/report.test.js
@@ -1,5 +1,6 @@
 import { createServer } from '~/src/api/server.js'
 import { runMetricsCollectionJob } from '~/src/service/metrics-job.js'
+import { generateSubmissionsReport } from '~/src/service/metrics-submissions.js'
 import {
   generateDrilldownReport,
   generateReport,
@@ -9,6 +10,7 @@ import { authSuperAdmin as auth } from '~/test/fixtures/auth.js'
 
 jest.mock('~/src/service/metrics.js')
 jest.mock('~/src/service/metrics-job.js')
+jest.mock('~/src/service/metrics-submissions.js')
 jest.mock('~/src/mongo.js')
 jest.mock('~/src/plugins/audit-cache.js')
 
@@ -78,6 +80,22 @@ describe('Report routes', () => {
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
       expect(response.result).toEqual({ overview: [], totals: null })
+    })
+
+    test('/report-submissions route returns 200', async () => {
+      jest
+        .mocked(generateSubmissionsReport)
+        .mockResolvedValue({ '2026-02': { 'form-id-1': 10 } })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/report-submissions',
+        auth
+      })
+
+      expect(response.statusCode).toEqual(okStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+      expect(response.result).toEqual({ '2026-02': { 'form-id-1': 10 } })
     })
   })
 

--- a/src/service/metrics-submissions.js
+++ b/src/service/metrics-submissions.js
@@ -1,5 +1,6 @@
 import { FormMetricName, FormStatus } from '@defra/forms-model'
-import { addDays, addMonths, format } from 'date-fns'
+import { addDays } from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
 
 import { client } from '~/src/mongo.js'
 import { getAllTimelineMetrics } from '~/src/repositories/metrics-repository.js'
@@ -12,6 +13,14 @@ const YEAR_MONTH_FORMAT = 'yyyy-MM'
  */
 
 /**
+ * Add leading zero to month, if needed
+ * @param {number} monthNum
+ */
+function lpadMonth(monthNum) {
+  return monthNum < 10 ? `0${monthNum}` : `${monthNum}`
+}
+
+/**
  * Generates a report of submissions each month per form
  * @param {Date} earliestDate - earliest date to build submissions counts
  */
@@ -22,13 +31,33 @@ export async function generateSubmissionsReport(earliestDate) {
   const submissionsMap = /** @type {SubmissionsMap} */ (new Map())
 
   // Pre-populate the month placeholders in the map
-  const yesterdayAsMonthYear = formatAsYearMonth(addDays(new Date(), -1))
-  let currentDate = formatAsYearMonth(earliestDate)
+  // Operate in UK timezone to avoid inaccuracies in month/year placeholders
+  const yesterday = addDays(new Date(), -1)
+
+  let currentMonth = parseInt(
+    formatInTimeZone(earliestDate, 'Europe/London', 'MM')
+  )
+  let currentYear = parseInt(
+    formatInTimeZone(earliestDate, 'Europe/London', 'yyyy')
+  )
+
+  const endMonth = parseInt(formatInTimeZone(yesterday, 'Europe/London', 'MM'))
+  const endYear = parseInt(formatInTimeZone(yesterday, 'Europe/London', 'yyyy'))
+
+  const endMonthYearStr = `${endYear}-${lpadMonth(endMonth)}`
+
+  let currentMonthYearStr
+
+  // Loop through each month of each year, from earliest date to end date
   do {
-    submissionsMap.set(currentDate, /** @type {FormsMap} */ (new Map()))
-    const nextMonth = addMonths(new Date(`${currentDate}-01`), 1)
-    currentDate = formatAsYearMonth(nextMonth)
-  } while (currentDate <= yesterdayAsMonthYear)
+    currentMonthYearStr = `${currentYear}-${lpadMonth(currentMonth)}`
+    submissionsMap.set(currentMonthYearStr, /** @type {FormsMap} */ (new Map()))
+    currentMonth++
+    if (currentMonth > 12) {
+      currentYear++
+      currentMonth = 1
+    }
+  } while (currentMonthYearStr < endMonthYearStr)
 
   try {
     // Live metrics only, and ignore any metrics from other languages otherwise we'll double-count
@@ -36,14 +65,15 @@ export async function generateSubmissionsReport(earliestDate) {
       {
         metricName: FormMetricName.Submissions,
         formStatus: FormStatus.Live,
+        createdAt: { $gte: earliestDate },
         language: { $exists: false }
       },
       session
     )
 
-    // Assign each submission metric to the appropriate month/form bucket
+    // Assign each submission metric to the appropriate month/form bucket (calculated in UK time)
     for await (const timeline of timelineCursor) {
-      const monthYear = formatAsYearMonth(timeline.createdAt)
+      const monthYear = formatAsYearMonthUK(timeline.createdAt)
       const monthMap = submissionsMap.get(monthYear)
       const count = monthMap?.get(timeline.formId) ?? 0
       monthMap?.set(timeline.formId, timeline.metricValue + count)
@@ -65,6 +95,6 @@ export async function generateSubmissionsReport(earliestDate) {
  * Format as year-month i.e. 2026-05
  * @param {Date} date
  */
-function formatAsYearMonth(date) {
-  return format(date, YEAR_MONTH_FORMAT)
+function formatAsYearMonthUK(date) {
+  return formatInTimeZone(date, 'Europe/London', YEAR_MONTH_FORMAT)
 }

--- a/src/service/metrics-submissions.js
+++ b/src/service/metrics-submissions.js
@@ -9,6 +9,7 @@ const YEAR_MONTH_FORMAT = 'yyyy-MM'
 const UK_TIMEZONE = 'Europe/London'
 const MM = 'MM'
 const YYYY = 'yyyy'
+const MONTHS_IN_A_YEAR = 12
 
 /**
  * @typedef {Map<string, number>} FormsMap
@@ -52,7 +53,7 @@ export async function generateSubmissionsReport(earliestDate) {
     currentMonthYearStr = `${currentYear}-${lpadMonth(currentMonth)}`
     submissionsMap.set(currentMonthYearStr, /** @type {FormsMap} */ (new Map()))
     currentMonth++
-    if (currentMonth > 12) {
+    if (currentMonth > MONTHS_IN_A_YEAR) {
       currentYear++
       currentMonth = 1
     }

--- a/src/service/metrics-submissions.js
+++ b/src/service/metrics-submissions.js
@@ -6,6 +6,9 @@ import { client } from '~/src/mongo.js'
 import { getAllTimelineMetrics } from '~/src/repositories/metrics-repository.js'
 
 const YEAR_MONTH_FORMAT = 'yyyy-MM'
+const UK_TIMEZONE = 'Europe/London'
+const MM = 'MM'
+const YYYY = 'yyyy'
 
 /**
  * @typedef {Map<string, number>} FormsMap
@@ -34,15 +37,11 @@ export async function generateSubmissionsReport(earliestDate) {
   // Operate in UK timezone to avoid inaccuracies in month/year placeholders
   const yesterday = addDays(new Date(), -1)
 
-  let currentMonth = parseInt(
-    formatInTimeZone(earliestDate, 'Europe/London', 'MM')
-  )
-  let currentYear = parseInt(
-    formatInTimeZone(earliestDate, 'Europe/London', 'yyyy')
-  )
+  let currentMonth = parseInt(formatInTimeZone(earliestDate, UK_TIMEZONE, MM))
+  let currentYear = parseInt(formatInTimeZone(earliestDate, UK_TIMEZONE, YYYY))
 
-  const endMonth = parseInt(formatInTimeZone(yesterday, 'Europe/London', 'MM'))
-  const endYear = parseInt(formatInTimeZone(yesterday, 'Europe/London', 'yyyy'))
+  const endMonth = parseInt(formatInTimeZone(yesterday, UK_TIMEZONE, MM))
+  const endYear = parseInt(formatInTimeZone(yesterday, UK_TIMEZONE, YYYY))
 
   const endMonthYearStr = `${endYear}-${lpadMonth(endMonth)}`
 
@@ -57,7 +56,7 @@ export async function generateSubmissionsReport(earliestDate) {
       currentYear++
       currentMonth = 1
     }
-  } while (currentMonthYearStr < endMonthYearStr)
+  } while (currentMonthYearStr.localeCompare(endMonthYearStr))
 
   try {
     // Live metrics only, and ignore any metrics from other languages otherwise we'll double-count
@@ -96,5 +95,5 @@ export async function generateSubmissionsReport(earliestDate) {
  * @param {Date} date
  */
 function formatAsYearMonthUK(date) {
-  return formatInTimeZone(date, 'Europe/London', YEAR_MONTH_FORMAT)
+  return formatInTimeZone(date, UK_TIMEZONE, YEAR_MONTH_FORMAT)
 }

--- a/src/service/metrics-submissions.js
+++ b/src/service/metrics-submissions.js
@@ -31,9 +31,13 @@ export async function generateSubmissionsReport(earliestDate) {
   } while (currentDate <= yesterdayAsMonthYear)
 
   try {
-    // Live metrics only
+    // Live metrics only, and ignore any metrics from other languages otherwise we'll double-count
     const timelineCursor = getAllTimelineMetrics(
-      { metricName: FormMetricName.Submissions, formStatus: FormStatus.Live },
+      {
+        metricName: FormMetricName.Submissions,
+        formStatus: FormStatus.Live,
+        language: { $exists: false }
+      },
       session
     )
 

--- a/src/service/metrics-submissions.js
+++ b/src/service/metrics-submissions.js
@@ -63,7 +63,7 @@ export async function generateSubmissionsReport(earliestDate) {
       currentYear++
       currentMonth = 1
     }
-  } while (currentMonthYearStr.localeCompare(endMonthYearStr))
+  } while (currentMonthYearStr.localeCompare(endMonthYearStr) < 0)
 
   try {
     // Live metrics only, and ignore any metrics from other languages otherwise we'll double-count

--- a/src/service/metrics-submissions.js
+++ b/src/service/metrics-submissions.js
@@ -26,7 +26,7 @@ function lpadMonth(monthNum) {
 
 /**
  * Generates a report of submissions each month per form
- * @param {Date} earliestDate - earliest date to build submissions counts
+ * @param {Date} earliestDate - earliest date to build submissions count month/year buckets
  */
 export async function generateSubmissionsReport(earliestDate) {
   const session = client.startSession()
@@ -67,11 +67,12 @@ export async function generateSubmissionsReport(earliestDate) {
 
   try {
     // Live metrics only, and ignore any metrics from other languages otherwise we'll double-count
+    // We don't need to filter on 'earliestDate' as that was purely for constructing the month/year buckets.
+    // All records of type 'Submissions' will be read here.
     const timelineCursor = getAllTimelineMetrics(
       {
         metricName: FormMetricName.Submissions,
         formStatus: FormStatus.Live,
-        createdAt: { $gte: earliestDate },
         language: { $exists: false }
       },
       session

--- a/src/service/metrics-submissions.js
+++ b/src/service/metrics-submissions.js
@@ -1,0 +1,66 @@
+import { FormMetricName, FormStatus } from '@defra/forms-model'
+import { addDays, addMonths, format } from 'date-fns'
+
+import { client } from '~/src/mongo.js'
+import { getAllTimelineMetrics } from '~/src/repositories/metrics-repository.js'
+
+const YEAR_MONTH_FORMAT = 'yyyy-MM'
+
+/**
+ * @typedef {Map<string, number>} FormsMap
+ * @typedef {Map<string, FormsMap>} SubmissionsMap
+ */
+
+/**
+ * Generates a report of submissions each month per form
+ * @param {Date} earliestDate - earliest date to build submissions counts
+ */
+export async function generateSubmissionsReport(earliestDate) {
+  const session = client.startSession()
+
+  // Map of months. Within each month is a map of formIds and their submission counts
+  const submissionsMap = /** @type {SubmissionsMap} */ (new Map())
+
+  // Pre-populate the month placeholders in the map
+  const yesterdayAsMonthYear = formatAsYearMonth(addDays(new Date(), -1))
+  let currentDate = formatAsYearMonth(earliestDate)
+  do {
+    submissionsMap.set(currentDate, /** @type {FormsMap} */ (new Map()))
+    const nextMonth = addMonths(new Date(`${currentDate}-01`), 1)
+    currentDate = formatAsYearMonth(nextMonth)
+  } while (currentDate <= yesterdayAsMonthYear)
+
+  try {
+    // Live metrics only
+    const timelineCursor = getAllTimelineMetrics(
+      { metricName: FormMetricName.Submissions, formStatus: FormStatus.Live },
+      session
+    )
+
+    // Assign each submission metric to the appropriate month/form bucket
+    for await (const timeline of timelineCursor) {
+      const monthYear = formatAsYearMonth(timeline.createdAt)
+      const monthMap = submissionsMap.get(monthYear)
+      const count = monthMap?.get(timeline.formId) ?? 0
+      monthMap?.set(timeline.formId, timeline.metricValue + count)
+    }
+
+    // Convert nested map into a JSON structure
+    return Object.fromEntries(
+      [...submissionsMap].map(([key, innerMap]) => [
+        key,
+        Object.fromEntries(innerMap)
+      ])
+    )
+  } finally {
+    await session.endSession()
+  }
+}
+
+/**
+ * Format as year-month i.e. 2026-05
+ * @param {Date} date
+ */
+function formatAsYearMonth(date) {
+  return format(date, YEAR_MONTH_FORMAT)
+}

--- a/src/service/metrics-submissions.js
+++ b/src/service/metrics-submissions.js
@@ -38,11 +38,17 @@ export async function generateSubmissionsReport(earliestDate) {
   // Operate in UK timezone to avoid inaccuracies in month/year placeholders
   const yesterday = addDays(new Date(), -1)
 
-  let currentMonth = parseInt(formatInTimeZone(earliestDate, UK_TIMEZONE, MM))
-  let currentYear = parseInt(formatInTimeZone(earliestDate, UK_TIMEZONE, YYYY))
+  let currentMonth = Number.parseInt(
+    formatInTimeZone(earliestDate, UK_TIMEZONE, MM)
+  )
+  let currentYear = Number.parseInt(
+    formatInTimeZone(earliestDate, UK_TIMEZONE, YYYY)
+  )
 
-  const endMonth = parseInt(formatInTimeZone(yesterday, UK_TIMEZONE, MM))
-  const endYear = parseInt(formatInTimeZone(yesterday, UK_TIMEZONE, YYYY))
+  const endMonth = Number.parseInt(formatInTimeZone(yesterday, UK_TIMEZONE, MM))
+  const endYear = Number.parseInt(
+    formatInTimeZone(yesterday, UK_TIMEZONE, YYYY)
+  )
 
   const endMonthYearStr = `${endYear}-${lpadMonth(endMonth)}`
 

--- a/src/service/metrics-submissions.test.js
+++ b/src/service/metrics-submissions.test.js
@@ -133,6 +133,39 @@ describe('metrics-submissions', () => {
       '2026-04': {}
     })
   })
+
+  it('should prevent endlees loop if future date supplied by accident', async () => {
+    const timelineMetrics = /** @type {FormTimelineMetric[]} */ ([
+      {
+        type: FormMetricType.TimelineMetric,
+        formId: 'form-id-1',
+        formStatus: FormStatus.Live,
+        metricName: FormMetricName.Submissions,
+        metricValue: 5,
+        createdAt: new Date('2025-12-10T10:00:00.000Z')
+      }
+    ])
+    const mockAsyncIterator = {
+      [Symbol.asyncIterator]: function* () {
+        for (const metric of timelineMetrics) {
+          yield metric
+        }
+      }
+    }
+    mockCollection.find
+      .mockReturnValueOnce({
+        sort: jest.fn(() => mockAsyncIterator)
+      })
+      .mockReturnValueOnce({
+        sort: jest.fn(() => mockAsyncIterator)
+      })
+
+    // Ensure months wrap around time-change months correctly
+    const res = await generateSubmissionsReport(new Date(2028, 1, 1))
+    expect(res).toEqual({
+      '2028-02': {}
+    })
+  })
 })
 
 /**

--- a/src/service/metrics-submissions.test.js
+++ b/src/service/metrics-submissions.test.js
@@ -83,12 +83,42 @@ describe('metrics-submissions', () => {
         }
       }
     }
-    mockCollection.find.mockReturnValueOnce({
-      sort: jest.fn(() => mockAsyncIterator)
+    mockCollection.find
+      .mockReturnValueOnce({
+        sort: jest.fn(() => mockAsyncIterator)
+      })
+      .mockReturnValueOnce({
+        sort: jest.fn(() => mockAsyncIterator)
+      })
+
+    // Ensure months wrap around time-change months correctly
+    const res = await generateSubmissionsReport(new Date(2025, 1, 1)) // 01/02/2025
+    expect(res).toEqual({
+      '2025-02': {},
+      '2025-03': {},
+      '2025-04': {},
+      '2025-05': {},
+      '2025-06': {},
+      '2025-07': {},
+      '2025-08': {},
+      '2025-09': {},
+      '2025-10': {},
+      '2025-11': {},
+      '2025-12': {
+        'form-id-1': 5,
+        'form-id-2': 10
+      },
+      '2026-01': {
+        'form-id-1': 1
+      },
+      '2026-02': {},
+      '2026-03': {},
+      '2026-04': {}
     })
 
-    const res = await generateSubmissionsReport(new Date(2025, 9, 1))
-    expect(res).toEqual({
+    // Ensure start month in time-change month handles correctly
+    const res2 = await generateSubmissionsReport(new Date(2025, 9, 1)) // 01/10/2025
+    expect(res2).toEqual({
       '2025-10': {},
       '2025-11': {},
       '2025-12': {

--- a/src/service/metrics-submissions.test.js
+++ b/src/service/metrics-submissions.test.js
@@ -1,0 +1,110 @@
+import { FormMetricName, FormMetricType, FormStatus } from '@defra/forms-model'
+
+import { buildMockCollection } from '~/src/api/forms/__stubs__/mongo.js'
+import { db } from '~/src/mongo.js'
+import { generateSubmissionsReport } from '~/src/service/metrics-submissions.js'
+
+const mockCollection = buildMockCollection()
+
+jest.mock('~/src/mongo.js', () => {
+  const collection = /** @satisfies {Collection<FormTimelineMetric>} */ jest
+    .fn()
+    .mockImplementation(() => mockCollection)
+  return {
+    db: {
+      collection
+    },
+    get client() {
+      return {
+        startSession: () => ({
+          endSession: jest.fn().mockResolvedValue(undefined),
+          withTransaction: jest.fn(
+            /**
+             * Mock transaction handler
+             * @param {() => Promise<void>} fn
+             */
+            async (fn) => fn()
+          )
+        })
+      }
+    }
+  }
+})
+
+describe('metrics-submissions', () => {
+  beforeEach(() => {
+    jest.mocked(db.collection).mockReturnValue(mockCollection)
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-02'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('should return submissions metrics by month per form', async () => {
+    const timelineMetrics = /** @type {FormTimelineMetric[]} */ ([
+      {
+        type: FormMetricType.TimelineMetric,
+        formId: 'form-id-1',
+        formStatus: FormStatus.Live,
+        metricName: FormMetricName.Submissions,
+        metricValue: 5,
+        createdAt: new Date('2025-12-10T10:00:00.000Z')
+      },
+      {
+        type: FormMetricType.TimelineMetric,
+        formId: 'form-id-1',
+        formStatus: FormStatus.Live,
+        metricName: FormMetricName.Submissions,
+        metricValue: 1,
+        createdAt: new Date('2026-01-01T10:00:00.000Z')
+      },
+      {
+        type: FormMetricType.TimelineMetric,
+        formId: 'form-id-2',
+        formStatus: FormStatus.Live,
+        metricName: FormMetricName.Submissions,
+        metricValue: 6,
+        createdAt: new Date('2025-12-29T10:00:00.000Z')
+      },
+      {
+        type: FormMetricType.TimelineMetric,
+        formId: 'form-id-2',
+        formStatus: FormStatus.Live,
+        metricName: FormMetricName.Submissions,
+        metricValue: 4,
+        createdAt: new Date('2025-12-30T10:00:00.000Z')
+      }
+    ])
+    const mockAsyncIterator = {
+      [Symbol.asyncIterator]: function* () {
+        for (const metric of timelineMetrics) {
+          yield metric
+        }
+      }
+    }
+    mockCollection.find.mockReturnValueOnce({
+      sort: jest.fn(() => mockAsyncIterator)
+    })
+
+    const res = await generateSubmissionsReport(new Date(2025, 9, 1))
+    expect(res).toEqual({
+      '2025-10': {},
+      '2025-11': {},
+      '2025-12': {
+        'form-id-1': 5,
+        'form-id-2': 10
+      },
+      '2026-01': {
+        'form-id-1': 1
+      },
+      '2026-02': {},
+      '2026-03': {},
+      '2026-04': {}
+    })
+  })
+})
+
+/**
+ * @import { FormTimelineMetric } from '@defra/forms-model'
+ */

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -23,6 +23,7 @@ import { getAuditRecordsOfType } from '~/src/repositories/audit-record-repositor
 import {
   getFirstDraft,
   getLanguageFilter,
+  getLanguageNoPropertyFilter,
   isFirstPublish
 } from '~/src/repositories/metrics-repository-helper.js'
 import {
@@ -71,7 +72,7 @@ import {
 const managerUrl = config.get('managerUrl')
 const submissionUrl = config.get('submissionUrl')
 
-const EARLIEST_REPORT_DATE_AS_STRING = '2025-07-01'
+export const EARLIEST_REPORT_DATE_AS_STRING = '2025-07-01'
 const METRICS_FORM_BATCH_SIZE = 20
 
 /**
@@ -435,7 +436,7 @@ export async function recalcMetrics(reportingDate, language, session, formId) {
 
   const metricCursor = formId
     ? getFormTimelineMetricsCursor(formId, language, session)
-    : getAllTimelineMetrics(language, session)
+    : getAllTimelineMetrics(getLanguageNoPropertyFilter(language), session)
 
   for await (const metric of metricCursor) {
     // FormsInDraft needs special attention since the cursor will return values from 'all' and other languages (e.g. Welsh),


### PR DESCRIPTION
Returns monthly submission metrics per form
e.g.
```
{
  '2025-10': {},
  '2025-11': {},
  '2025-12': {
    'form-id-1': 5,
    'form-id-2': 10
  },
  '2026-01': {
    'form-id-1': 1
  },
  '2026-02': {},
  '2026-03': {},
  '2026-04': {}
}
```